### PR TITLE
feat(adapter-spec): define minimal Adapter contract (M2)

### DIFF
--- a/packages/adapter-spec/package.json
+++ b/packages/adapter-spec/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@decoro/adapter-spec",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "check": "vp check",
+    "check:write": "vp check --fix"
+  },
+  "dependencies": {
+    "@json-render/core": "0.18.0"
+  }
+}

--- a/packages/adapter-spec/src/index.ts
+++ b/packages/adapter-spec/src/index.ts
@@ -1,0 +1,45 @@
+import type { Catalog } from '@json-render/core';
+
+/**
+ * Free-form description of the target component library, surfaced in the UI
+ * and threaded into the generation prompt.
+ */
+export type AdapterMetadata = {
+  name: string;
+  version: string;
+  designPrinciples: string;
+};
+
+/**
+ * Mapping from Catalog component name to a concrete component implementation.
+ *
+ * Parametric in `TComponent` so `@decoro/core` can stay framework-agnostic
+ * (per ADR-004). Concrete adapters specialize this — e.g.
+ * `adapter-arte-odyssey` will pin it to React component types.
+ */
+export type AdapterRegistry<TComponent = unknown> = Record<string, TComponent>;
+
+/**
+ * Hooks an adapter exposes for turning a `json-render` Spec into TSX.
+ *
+ * Loose by design — refined in M9 (`json-render` codegen wiring) once the
+ * concrete needs are known. ADR-004: do not pre-abstract.
+ */
+export type AdapterCodeOutput = {
+  /** Module path the generated TSX imports components from. */
+  importPath: string;
+};
+
+/**
+ * What an adapter must expose so Decoro can drive UI generation against a
+ * specific component library.
+ *
+ * Intentionally minimal. Fields will harden as `adapter-arte-odyssey` (M3)
+ * and the codegen wiring (M9) force them to.
+ */
+export type Adapter<TComponent = unknown> = {
+  metadata: AdapterMetadata;
+  catalog: Catalog;
+  registry: AdapterRegistry<TComponent>;
+  codeOutput: AdapterCodeOutput;
+};

--- a/packages/adapter-spec/tsconfig.json
+++ b/packages/adapter-spec/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,12 @@ importers:
         specifier: 'catalog:'
         version: 0.1.19(@types/node@24.12.2)(jiti@2.6.1)(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))
 
+  packages/adapter-spec:
+    dependencies:
+      '@json-render/core':
+        specifier: 0.18.0
+        version: 0.18.0(zod@4.3.6)
+
 packages:
 
   '@babel/code-frame@7.29.0':
@@ -132,6 +138,11 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@json-render/core@0.18.0':
+    resolution: {integrity: sha512-zm0K9cgxZLGshw5TmdKe3Xc6fpjbONdlj3v+Er+HhCYZ9fSJpv32d9VzQds4bDW36vPfdieAOcsPR9+EcTff7Q==}
+    peerDependencies:
+      zod: ^4.0.0
 
   '@k8o/oxc-config@0.1.2':
     resolution: {integrity: sha512-AsrHdwWPLI9UUCF4j+8UANLLDWHHRtLaIrGkC+KbW4cAIzb+ag30nAVzWKViVB7+tgKp7Du96iWfmApTSDC5fQ==}
@@ -1186,6 +1197,9 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
 snapshots:
 
   '@babel/code-frame@7.29.0':
@@ -1333,6 +1347,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@json-render/core@0.18.0(zod@4.3.6)':
+    dependencies:
+      zod: 4.3.6
 
   '@k8o/oxc-config@0.1.2(oxfmt@0.45.0)(oxlint@1.60.0(oxlint-tsgolint@0.21.1))':
     optionalDependencies:
@@ -2082,3 +2100,5 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  zod@4.3.6: {}


### PR DESCRIPTION
## Summary

Stand up `packages/adapter-spec` with the minimal contract every adapter must expose: metadata, catalog (from `@json-render/core`), registry, and code-output template.

Per ADR-004 the shape is deliberately coarse and will harden as `adapter-arte-odyssey` (M3) and the codegen wiring (M9) force it to.

- `registry` is parametric in the component type so `@decoro/core` can stay framework-agnostic — `adapter-arte-odyssey` will pin it to React component types.
- `codeOutput` exposes only `importPath` today; M9 refines it once we wire `json-render`'s codegen.

Closes #2

## Test plan

- [x] \`pnpm install\` succeeds
- [x] \`pnpm typecheck\` passes
- [x] \`pnpm check\` (fmt + lint + tsc) passes