### PR TITLE
feat(adapter-arte-odyssey): minimal Catalog with Button + Card (M3)

### DIFF
--- a/packages/adapter-arte-odyssey/package.json
+++ b/packages/adapter-arte-odyssey/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@decoro/adapter-arte-odyssey",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "vp test --run",
+    "typecheck": "tsc --noEmit",
+    "check": "vp check",
+    "check:write": "vp check --fix"
+  },
+  "dependencies": {
+    "@decoro/adapter-spec": "workspace:^",
+    "@json-render/core": "0.18.0",
+    "@json-render/react": "0.18.0",
+    "@k8o/arte-odyssey": "7.0.1",
+    "react": "catalog:",
+    "zod": "4.3.6"
+  },
+  "devDependencies": {
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitejs/plugin-react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0"
+  }
+}

--- a/packages/adapter-arte-odyssey/src/adapter.test.tsx
+++ b/packages/adapter-arte-odyssey/src/adapter.test.tsx
@@ -1,0 +1,59 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { arteOdysseyAdapter } from './index.ts';
+
+const fakeRenderProps = <P,>(element: { type: string; props: P }) => ({
+  element: { key: 'k1', children: [], visible: undefined, ...element },
+  emit: () => {},
+  on: () => ({
+    shouldPreventDefault: false,
+    bound: false,
+    emit: () => {},
+  }),
+});
+
+describe('adapter-arte-odyssey', () => {
+  it('exposes Button and Card in the registry', () => {
+    expect(arteOdysseyAdapter.registry).toHaveProperty('Button');
+    expect(arteOdysseyAdapter.registry).toHaveProperty('Card');
+  });
+
+  it('declares the import path used by code generation', () => {
+    expect(arteOdysseyAdapter.codeOutput.importPath).toBe('@k8o/arte-odyssey');
+  });
+
+  it('renders Card via the registry', () => {
+    const CardRenderer = arteOdysseyAdapter.registry['Card']!;
+    const html = renderToStaticMarkup(
+      createElement(
+        CardRenderer,
+        fakeRenderProps({ type: 'Card', props: {} }),
+        'hello world',
+      ),
+    );
+    expect(html).toContain('hello world');
+  });
+
+  it('renders Button via the registry', () => {
+    const ButtonRenderer = arteOdysseyAdapter.registry['Button']!;
+    const html = renderToStaticMarkup(
+      createElement(
+        ButtonRenderer,
+        fakeRenderProps({
+          type: 'Button',
+          props: {
+            label: 'Submit',
+            type: null,
+            size: null,
+            color: null,
+            variant: null,
+            fullWidth: null,
+            disabled: null,
+          },
+        }),
+      ),
+    );
+    expect(html).toContain('Submit');
+  });
+});

--- a/packages/adapter-arte-odyssey/src/catalog.ts
+++ b/packages/adapter-arte-odyssey/src/catalog.ts
@@ -1,0 +1,39 @@
+import { defineCatalog } from '@json-render/core';
+import { schema } from '@json-render/react/schema';
+import { z } from 'zod';
+
+const buttonProps = z.object({
+  label: z.string().describe('Visible button text.'),
+  type: z.enum(['button', 'submit']).nullable(),
+  size: z.enum(['sm', 'md', 'lg']).nullable(),
+  color: z.enum(['primary', 'secondary', 'gray']).nullable(),
+  variant: z.enum(['contained', 'outlined', 'skeleton']).nullable(),
+  fullWidth: z.boolean().nullable(),
+  disabled: z.boolean().nullable(),
+});
+
+const cardProps = z.object({
+  width: z.enum(['full', 'fit']).nullable(),
+  appearance: z.enum(['shadow', 'bordered']).nullable(),
+});
+
+export const catalog = defineCatalog(schema, {
+  components: {
+    Button: {
+      props: buttonProps,
+      slots: [],
+      description:
+        'Standard ArteOdyssey button. Use for actions; the visible text comes from `label`. Pick `color` and `variant` based on prominence.',
+    },
+    Card: {
+      props: cardProps,
+      slots: ['default'],
+      description:
+        'Container for grouping content. Use `appearance: "bordered"` when stacking multiple cards on the same surface, otherwise leave the default shadow.',
+    },
+  },
+  actions: {},
+});
+
+export type ButtonProps = z.infer<typeof buttonProps>;
+export type CardProps = z.infer<typeof cardProps>;

--- a/packages/adapter-arte-odyssey/src/code-output.ts
+++ b/packages/adapter-arte-odyssey/src/code-output.ts
@@ -1,0 +1,5 @@
+import type { AdapterCodeOutput } from '@decoro/adapter-spec';
+
+export const codeOutput: AdapterCodeOutput = {
+  importPath: '@k8o/arte-odyssey',
+};

--- a/packages/adapter-arte-odyssey/src/index.ts
+++ b/packages/adapter-arte-odyssey/src/index.ts
@@ -1,0 +1,17 @@
+import type { Adapter } from '@decoro/adapter-spec';
+import type { ComponentRenderer } from '@json-render/react';
+
+import { catalog } from './catalog.ts';
+import { codeOutput } from './code-output.ts';
+import { metadata } from './metadata.ts';
+import { registry } from './registry.tsx';
+
+export const arteOdysseyAdapter: Adapter<ComponentRenderer> = {
+  metadata,
+  catalog,
+  registry,
+  codeOutput,
+};
+
+export { catalog, codeOutput, metadata, registry };
+export type { ButtonProps, CardProps } from './catalog.ts';

--- a/packages/adapter-arte-odyssey/src/metadata.ts
+++ b/packages/adapter-arte-odyssey/src/metadata.ts
@@ -1,0 +1,14 @@
+import type { AdapterMetadata } from '@decoro/adapter-spec';
+
+export const metadata: AdapterMetadata = {
+  name: '@k8o/arte-odyssey',
+  version: '7.0.1',
+  designPrinciples: [
+    'ArteOdyssey is a React + TypeScript + Tailwind CSS 4 design system.',
+    'Prefer semantic, accessible components over div soup.',
+    'Color: primary for the main call to action, secondary for supporting actions, gray for neutral / cancel.',
+    'Variants: contained for prominence, outlined for secondary affordance, skeleton for ghost/inline use.',
+    'Sizes: sm / md / lg. Default to md unless density demands otherwise.',
+    'Spacing and rounded corners follow the library defaults — do not override with raw Tailwind unless asked.',
+  ].join('\n'),
+};

--- a/packages/adapter-arte-odyssey/src/registry.tsx
+++ b/packages/adapter-arte-odyssey/src/registry.tsx
@@ -1,0 +1,41 @@
+import type {
+  ComponentRegistry,
+  ComponentRenderProps,
+} from '@json-render/react';
+import { Button, Card } from '@k8o/arte-odyssey';
+
+import type { ButtonProps, CardProps } from './catalog.ts';
+
+const ButtonRenderer = ({ element }: ComponentRenderProps<ButtonProps>) => {
+  const { label, type, size, color, variant, fullWidth, disabled } =
+    element.props;
+  return (
+    <Button
+      type={type ?? undefined}
+      size={size ?? undefined}
+      color={color ?? undefined}
+      variant={variant ?? undefined}
+      fullWidth={fullWidth ?? undefined}
+      disabled={disabled ?? undefined}
+    >
+      {label}
+    </Button>
+  );
+};
+
+const CardRenderer = ({
+  element,
+  children,
+}: ComponentRenderProps<CardProps>) => {
+  const { width, appearance } = element.props;
+  return (
+    <Card width={width ?? undefined} appearance={appearance ?? undefined}>
+      {children}
+    </Card>
+  );
+};
+
+export const registry: ComponentRegistry = {
+  Button: ButtonRenderer,
+  Card: CardRenderer,
+};

--- a/packages/adapter-arte-odyssey/tsconfig.json
+++ b/packages/adapter-arte-odyssey/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/packages/adapter-arte-odyssey/vite.config.ts
+++ b/packages/adapter-arte-odyssey/vite.config.ts
@@ -1,0 +1,10 @@
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite-plus';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    include: ['src/**/*.test.{ts,tsx}'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,21 @@ settings:
 
 catalogs:
   default:
+    '@types/react':
+      specifier: 19.2.14
+      version: 19.2.14
+    '@types/react-dom':
+      specifier: 19.2.3
+      version: 19.2.3
+    '@vitejs/plugin-react':
+      specifier: 6.0.1
+      version: 6.0.1
+    react:
+      specifier: 19.2.5
+      version: 19.2.5
+    react-dom:
+      specifier: 19.2.5
+      version: 19.2.5
     vite-plus:
       specifier: 0.1.19
       version: 0.1.19
@@ -32,6 +47,40 @@ importers:
       vite-plus:
         specifier: 'catalog:'
         version: 0.1.19(@types/node@24.12.2)(jiti@2.6.1)(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))
+
+  packages/adapter-arte-odyssey:
+    dependencies:
+      '@decoro/adapter-spec':
+        specifier: workspace:^
+        version: link:../adapter-spec
+      '@json-render/core':
+        specifier: 0.18.0
+        version: 0.18.0(zod@4.3.6)
+      '@json-render/react':
+        specifier: 0.18.0
+        version: 0.18.0(react@19.2.5)(zod@4.3.6)
+      '@k8o/arte-odyssey':
+        specifier: 7.0.1
+        version: 7.0.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.2.4)(typescript@6.0.3)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      zod:
+        specifier: 4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: 'catalog:'
+        version: 6.0.1(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
 
   packages/adapter-spec:
     dependencies:
@@ -139,10 +188,46 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/react@0.27.19':
+    resolution: {integrity: sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==}
+    peerDependencies:
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
   '@json-render/core@0.18.0':
     resolution: {integrity: sha512-zm0K9cgxZLGshw5TmdKe3Xc6fpjbONdlj3v+Er+HhCYZ9fSJpv32d9VzQds4bDW36vPfdieAOcsPR9+EcTff7Q==}
     peerDependencies:
       zod: ^4.0.0
+
+  '@json-render/react@0.18.0':
+    resolution: {integrity: sha512-rT0hJ9mK2BGfLxZ/ztS4UF1XqAz/o+FNtFgii7hea7VjD4u0wJYyRphe4a5DetS/dSMZFECXkmida+xi3wKl9A==}
+    peerDependencies:
+      react: ^19.2.3
+
+  '@k8o/arte-odyssey@7.0.1':
+    resolution: {integrity: sha512-SzHxcEahM+N0BECP732KMVxcCVkwc45kvFVqa9ZlaCKj1iWqPjCHTskcqPaoYh5MCOMa6gescEAfmMLB34ph0Q==}
+    peerDependencies:
+      '@types/react': '>=19.0.0'
+      '@types/react-dom': '>=19.0.0'
+      react: '>=19.0.0'
+      react-dom: '>=19.0.0'
+      tailwindcss: '>=4.0.0'
+      typescript: '>=5.9.0'
 
   '@k8o/oxc-config@0.1.2':
     resolution: {integrity: sha512-AsrHdwWPLI9UUCF4j+8UANLLDWHHRtLaIrGkC+KbW4cAIzb+ag30nAVzWKViVB7+tgKp7Du96iWfmApTSDC5fQ==}
@@ -158,6 +243,15 @@ packages:
         optional: true
       oxlint-tailwindcss:
         optional: true
+
+  '@lit-labs/ssr-dom-shim@1.5.1':
+    resolution: {integrity: sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==}
+
+  '@lit/reactive-element@2.1.2':
+    resolution: {integrity: sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==}
+
+  '@lit/task@1.0.3':
+    resolution: {integrity: sha512-1gJGJl8WON+2j0y9xfcD+XsS1rvcy3XDgsIhcdUW++yTR8ESjZW6o7dn8M8a4SZM8NnJe6ynS2cKWwsbfLOurg==}
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -550,6 +644,9 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.17':
     resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
 
+  '@rolldown/pluginutils@1.0.0-rc.7':
+    resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
+
   '@simple-libs/child-process-utils@1.0.2':
     resolution: {integrity: sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==}
     engines: {node: '>=18'}
@@ -572,6 +669,30 @@ packages:
 
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@vitejs/plugin-react@6.0.1':
+    resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
 
   '@voidzero-dev/vite-plus-core@0.1.19':
     resolution: {integrity: sha512-BTmz50juSDolIN4Vtu5iVaPONV1XSrMB5V+9IoBhhxdogfvp7PBhaHuAcPjTN2RTVowhLZXoo8mn+aHjq//bkw==}
@@ -737,6 +858,9 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  baseline-status@1.1.1:
+    resolution: {integrity: sha512-l7L5D3MQA/+082HNaN2vEeodO20wVC6SctPCPmediuxHlGkBxQcbo2fYfTB+4FYg4QbRTTig4xI5Tyy1aRCJ3A==}
+
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -744,6 +868,10 @@ packages:
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -785,6 +913,9 @@ packages:
       typescript:
         optional: true
 
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -823,6 +954,20 @@ packages:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
       picomatch:
+        optional: true
+
+  framer-motion@12.38.0:
+    resolution: {integrity: sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
         optional: true
 
   fsevents@2.3.3:
@@ -963,6 +1108,15 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  lit-element@4.2.2:
+    resolution: {integrity: sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==}
+
+  lit-html@3.3.2:
+    resolution: {integrity: sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==}
+
+  lit@3.3.2:
+    resolution: {integrity: sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==}
+
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
@@ -981,12 +1135,37 @@ packages:
   lodash.upperfirst@4.3.1:
     resolution: {integrity: sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==}
 
+  lucide-react@1.9.0:
+    resolution: {integrity: sha512-6qVAmbgCjcJz7sAGSPSSJ++RAwjlK2XCbRrZKv63Ciko1KT8jX0//CXxgI3jg2HlJu8tADqdYlNDebmYjeoruA==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   meow@13.2.0:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
     engines: {node: '>=18'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  motion-dom@12.38.0:
+    resolution: {integrity: sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==}
+
+  motion-utils@12.36.0:
+    resolution: {integrity: sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==}
+
+  motion@12.38.0:
+    resolution: {integrity: sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -1046,6 +1225,15 @@ packages:
     resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
+  react-dom@19.2.5:
+    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
+    peerDependencies:
+      react: ^19.2.5
+
+  react@19.2.5:
+    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
+    engines: {node: '>=0.10.0'}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -1066,6 +1254,9 @@ packages:
     resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -1090,6 +1281,15 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  tabbable@6.4.0:
+    resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
+
+  tailwind-merge@3.5.0:
+    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
+
+  tailwindcss@4.2.4:
+    resolution: {integrity: sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1348,14 +1548,73 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@floating-ui/react@0.27.19(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      tabbable: 6.4.0
+
+  '@floating-ui/utils@0.2.11': {}
+
   '@json-render/core@0.18.0(zod@4.3.6)':
     dependencies:
       zod: 4.3.6
+
+  '@json-render/react@0.18.0(react@19.2.5)(zod@4.3.6)':
+    dependencies:
+      '@json-render/core': 0.18.0(zod@4.3.6)
+      react: 19.2.5
+    transitivePeerDependencies:
+      - zod
+
+  '@k8o/arte-odyssey@7.0.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.2.4)(typescript@6.0.3)':
+    dependencies:
+      '@floating-ui/react': 0.27.19(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      baseline-status: 1.1.1
+      clsx: 2.1.1
+      lucide-react: 1.9.0(react@19.2.5)
+      motion: 12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      tailwind-merge: 3.5.0
+      tailwindcss: 4.2.4
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
 
   '@k8o/oxc-config@0.1.2(oxfmt@0.45.0)(oxlint@1.60.0(oxlint-tsgolint@0.21.1))':
     optionalDependencies:
       oxfmt: 0.45.0
       oxlint: 1.60.0(oxlint-tsgolint@0.21.1)
+
+  '@lit-labs/ssr-dom-shim@1.5.1': {}
+
+  '@lit/reactive-element@2.1.2':
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.5.1
+
+  '@lit/task@1.0.3':
+    dependencies:
+      '@lit/reactive-element': 2.1.2
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -1555,6 +1814,8 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.17': {}
 
+  '@rolldown/pluginutils@1.0.0-rc.7': {}
+
   '@simple-libs/child-process-utils@1.0.2':
     dependencies:
       '@simple-libs/stream-utils': 1.2.0
@@ -1578,6 +1839,21 @@ snapshots:
   '@types/node@24.12.2':
     dependencies:
       undici-types: 7.16.0
+
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
+
+  '@types/trusted-types@2.0.7': {}
+
+  '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.7
+      vite: 8.0.10(@types/node@24.12.2)(jiti@2.6.1)
 
   '@voidzero-dev/vite-plus-core@0.1.19(@types/node@24.12.2)(jiti@2.6.1)(typescript@6.0.3)':
     dependencies:
@@ -1673,6 +1949,11 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  baseline-status@1.1.1:
+    dependencies:
+      '@lit/task': 1.0.3
+      lit: 3.3.2
+
   callsites@3.1.0: {}
 
   cliui@8.0.1:
@@ -1680,6 +1961,8 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+
+  clsx@2.1.1: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -1721,6 +2004,8 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
+  csstype@3.2.3: {}
+
   detect-libc@2.1.2: {}
 
   dot-prop@5.3.0:
@@ -1746,6 +2031,15 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  framer-motion@12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      motion-dom: 12.38.0
+      motion-utils: 12.36.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
   fsevents@2.3.3:
     optional: true
@@ -1844,6 +2138,22 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  lit-element@4.2.2:
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.5.1
+      '@lit/reactive-element': 2.1.2
+      lit-html: 3.3.2
+
+  lit-html@3.3.2:
+    dependencies:
+      '@types/trusted-types': 2.0.7
+
+  lit@3.3.2:
+    dependencies:
+      '@lit/reactive-element': 2.1.2
+      lit-element: 4.2.2
+      lit-html: 3.3.2
+
   lodash.camelcase@4.3.0: {}
 
   lodash.kebabcase@4.1.1: {}
@@ -1856,9 +2166,27 @@ snapshots:
 
   lodash.upperfirst@4.3.1: {}
 
+  lucide-react@1.9.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+
   meow@13.2.0: {}
 
   minimist@1.2.8: {}
+
+  motion-dom@12.38.0:
+    dependencies:
+      motion-utils: 12.36.0
+
+  motion-utils@12.36.0: {}
+
+  motion@12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      framer-motion: 12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
   mrmime@2.0.1: {}
 
@@ -1949,6 +2277,13 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  react-dom@19.2.5(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      scheduler: 0.27.0
+
+  react@19.2.5: {}
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -1978,6 +2313,8 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
+  scheduler@0.27.0: {}
+
   semver@7.7.4: {}
 
   sirv@3.0.2:
@@ -2000,6 +2337,12 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
+  tabbable@6.4.0: {}
+
+  tailwind-merge@3.5.0: {}
+
+  tailwindcss@4.2.4: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@1.1.1: {}
@@ -2013,8 +2356,7 @@ snapshots:
 
   totalist@3.0.1: {}
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   typescript@6.0.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,11 @@ packages:
 blockExoticSubdeps: true
 
 catalog:
+  '@types/react': 19.2.14
+  '@types/react-dom': 19.2.3
+  '@vitejs/plugin-react': 6.0.1
+  react: 19.2.5
+  react-dom: 19.2.5
   vite-plus: 0.1.19
 
 allowBuilds:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,6 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noUncheckedIndexedAccess": true,
-    "types": ["node"]
+    "types": ["node", "vite-plus/test/globals", "vite-plus/test/importMeta"]
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { base, fmt } from '@k8o/oxc-config';
+import { base, fmt, test } from '@k8o/oxc-config';
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({
@@ -12,6 +12,14 @@ export default defineConfig({
     options: {
       reportUnusedDisableDirectives: 'error',
     },
+    overrides: [
+      {
+        files: ['**/*.test.ts', '**/*.test.tsx'],
+        plugins: [...(test.plugins ?? [])],
+        rules: test.rules ?? {},
+        env: { jest: true },
+      },
+    ],
   },
   staged: {
     '*.{js,ts,cjs,mjs,jsx,tsx,json,jsonc}': 'vp check --fix',


### PR DESCRIPTION
## Summary

Stand up the first concrete adapter — `@decoro/adapter-arte-odyssey` — covering ArteOdyssey Button and Card. This validates the M2 contract end-to-end with a real library.

- **Catalog** (\`@json-render/core\` \`defineCatalog\`) declares Button + Card with Zod-typed props.
- **Registry** wraps real ArteOdyssey components into the \`ComponentRenderer<Props>\` shape \`@json-render/react\` expects.
- **codeOutput.importPath** is \`@k8o/arte-odyssey\` — code generation in M9 will lower the spec into TSX that imports from here.
- **metadata.designPrinciples** is the prose threaded into the LLM prompt to teach it ArteOdyssey idioms.

## Toolchain follow-ups bundled here

These had to land alongside the package so test infra works repo-wide. Splitting them into a separate PR would have left M3 unrunnable.

- **pnpm-workspace.yaml catalog**: react / react-dom / @types/react / @types/react-dom / @vitejs/plugin-react (mirrors ArteOdyssey versions).
- **Root tsconfig types**: \`vite-plus/test/globals\` + \`vite-plus/test/importMeta\` so test files type-check.
- **Root vite.config.ts**: \`@k8o/oxc-config\` test override with \`env.jest=true\` so oxlint stops flagging \`describe\` / \`expect\` / \`it\` as undefined.

Closes #3

## Test plan

- [x] \`pnpm install\` succeeds
- [x] \`pnpm typecheck\` passes
- [x] \`pnpm test\` passes (4 tests: Button + Card render via registry, registry shape, codeOutput.importPath)
- [x] \`pnpm check\` (fmt + lint) passes