### PR TITLE
feat(apps/web): wire iframe preview with hard-coded spec (M5)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,8 @@
   "dependencies": {
     "@decoro/adapter-arte-odyssey": "workspace:^",
     "@decoro/adapter-spec": "workspace:^",
+    "@json-render/core": "0.18.0",
+    "@json-render/react": "0.18.0",
     "@k8o/arte-odyssey": "7.0.1",
     "next": "16.2.4",
     "react": "catalog:",

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,5 +1,8 @@
 import { Heading } from '@k8o/arte-odyssey';
 
+import { PreviewFrame } from '../components/preview-frame.tsx';
+import { sampleSpec } from '../lib/sample-spec.ts';
+
 const HomePage = () => (
   <div className="bg-bg-base text-fg-base flex h-dvh flex-col">
     <header className="border-border-mute border-b px-6 py-4">
@@ -13,11 +16,16 @@ const HomePage = () => (
         <Heading type="h2">Chat</Heading>
         <p className="text-fg-mute mt-2">Conversation UI lands in M7.</p>
       </section>
-      <section aria-label="Preview" className="w-1/2 p-6">
-        <Heading type="h2">Preview</Heading>
-        <p className="text-fg-mute mt-2">
-          The iframe-isolated preview lands in M5.
-        </p>
+      <section
+        aria-label="Preview"
+        className="flex w-1/2 flex-col overflow-hidden"
+      >
+        <div className="border-border-mute border-b px-6 py-4">
+          <Heading type="h2">Preview</Heading>
+        </div>
+        <div className="flex-1 overflow-hidden">
+          <PreviewFrame spec={sampleSpec} />
+        </div>
       </section>
     </div>
   </div>

--- a/apps/web/src/app/preview/page.tsx
+++ b/apps/web/src/app/preview/page.tsx
@@ -2,7 +2,7 @@
 
 import { arteOdysseyAdapter } from '@decoro/adapter-arte-odyssey';
 import type { Spec } from '@json-render/core';
-import { Renderer } from '@json-render/react';
+import { JSONUIProvider, Renderer } from '@json-render/react';
 import { useEffect, useState } from 'react';
 
 import {
@@ -32,7 +32,9 @@ const PreviewPage = () => {
   return (
     <div className="bg-bg-base text-fg-base min-h-dvh p-6">
       {spec ? (
-        <Renderer spec={spec} registry={arteOdysseyAdapter.registry} />
+        <JSONUIProvider registry={arteOdysseyAdapter.registry}>
+          <Renderer spec={spec} registry={arteOdysseyAdapter.registry} />
+        </JSONUIProvider>
       ) : (
         <p className="text-fg-mute">Waiting for a spec from the parent…</p>
       )}

--- a/apps/web/src/app/preview/page.tsx
+++ b/apps/web/src/app/preview/page.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { arteOdysseyAdapter } from '@decoro/adapter-arte-odyssey';
+import type { Spec } from '@json-render/core';
+import { Renderer } from '@json-render/react';
+import { useEffect, useState } from 'react';
+
+import {
+  type PreviewOutboundMessage,
+  isPreviewMessage,
+} from '../../lib/preview-message.ts';
+
+const PreviewPage = () => {
+  const [spec, setSpec] = useState<Spec | null>(null);
+
+  useEffect(() => {
+    const handler = (event: MessageEvent) => {
+      if (event.origin !== window.location.origin) return;
+      if (!isPreviewMessage(event.data)) return;
+      if (event.data.type === 'decoro:spec') setSpec(event.data.spec);
+    };
+    window.addEventListener('message', handler);
+
+    const ready: PreviewOutboundMessage = { type: 'decoro:ready' };
+    window.parent.postMessage(ready, window.location.origin);
+
+    return () => {
+      window.removeEventListener('message', handler);
+    };
+  }, []);
+
+  return (
+    <div className="bg-bg-base text-fg-base min-h-dvh p-6">
+      {spec ? (
+        <Renderer spec={spec} registry={arteOdysseyAdapter.registry} />
+      ) : (
+        <p className="text-fg-mute">Waiting for a spec from the parent…</p>
+      )}
+    </div>
+  );
+};
+
+export default PreviewPage;

--- a/apps/web/src/components/preview-frame.tsx
+++ b/apps/web/src/components/preview-frame.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import type { Spec } from '@json-render/core';
+import { useEffect, useRef, useState } from 'react';
+
+import {
+  type PreviewInboundMessage,
+  isPreviewMessage,
+} from '../lib/preview-message.ts';
+
+type Props = {
+  spec: Spec;
+};
+
+/**
+ * Hosts the `/preview` page in an iframe and pushes the current Spec into it
+ * via postMessage. Re-sends whenever `spec` changes after the iframe is ready.
+ */
+export const PreviewFrame = ({ spec }: Props) => {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    const handler = (event: MessageEvent) => {
+      if (event.origin !== window.location.origin) return;
+      if (!isPreviewMessage(event.data)) return;
+      if (event.data.type === 'decoro:ready') setReady(true);
+    };
+    window.addEventListener('message', handler);
+    return () => {
+      window.removeEventListener('message', handler);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!ready) return;
+    const message: PreviewInboundMessage = { type: 'decoro:spec', spec };
+    iframeRef.current?.contentWindow?.postMessage(
+      message,
+      window.location.origin,
+    );
+  }, [ready, spec]);
+
+  return (
+    // The iframe exists for style-space isolation (ADR-006), not for security
+    // sandboxing — both sides are first-party Decoro routes, so an HTML
+    // sandbox would only obstruct postMessage without buying anything.
+    // oxlint-disable-next-line eslint-plugin-react(iframe-missing-sandbox)
+    <iframe
+      ref={iframeRef}
+      src="/preview"
+      title="Decoro preview"
+      className="size-full border-0"
+    />
+  );
+};

--- a/apps/web/src/lib/preview-message.ts
+++ b/apps/web/src/lib/preview-message.ts
@@ -1,0 +1,23 @@
+import type { Spec } from '@json-render/core';
+
+/**
+ * Messages exchanged between the parent (`/`) and the preview iframe
+ * (`/preview`). All messages share a `decoro:` prefix to make them easy to
+ * filter from unrelated postMessage traffic.
+ */
+export type PreviewInboundMessage = {
+  type: 'decoro:spec';
+  spec: Spec;
+};
+
+export type PreviewOutboundMessage = {
+  type: 'decoro:ready';
+};
+
+export type PreviewMessage = PreviewInboundMessage | PreviewOutboundMessage;
+
+export const isPreviewMessage = (value: unknown): value is PreviewMessage => {
+  if (typeof value !== 'object' || value === null) return false;
+  const { type } = value as { type?: unknown };
+  return type === 'decoro:spec' || type === 'decoro:ready';
+};

--- a/apps/web/src/lib/sample-spec.ts
+++ b/apps/web/src/lib/sample-spec.ts
@@ -1,0 +1,25 @@
+import type { Spec } from '@json-render/core';
+
+/**
+ * Hard-coded demo Spec used in M5 to prove the iframe wiring works without
+ * the LLM. Replaced by the live LLM stream in M7.
+ */
+export const sampleSpec: Spec = {
+  root: 'demo-card',
+  elements: {
+    'demo-card': {
+      type: 'Card',
+      props: { appearance: 'shadow', width: 'fit' },
+      children: ['demo-button'],
+    },
+    'demo-button': {
+      type: 'Button',
+      props: {
+        label: 'Hello from the iframe',
+        color: 'primary',
+        variant: 'contained',
+      },
+      children: [],
+    },
+  },
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,9 +18,6 @@ catalogs:
     '@vitejs/plugin-react':
       specifier: 6.0.1
       version: 6.0.1
-    postcss:
-      specifier: 8.5.10
-      version: 8.5.10
     react:
       specifier: 19.2.5
       version: 19.2.5
@@ -33,6 +30,9 @@ catalogs:
     vite-plus:
       specifier: 0.1.19
       version: 0.1.19
+
+overrides:
+  postcss: '>=8.5.10'
 
 importers:
 
@@ -106,8 +106,8 @@ importers:
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.14)
       postcss:
-        specifier: 'catalog:'
-        version: 8.5.10
+        specifier: '>=8.5.10'
+        version: 8.5.12
 
   packages/adapter-arte-odyssey:
     dependencies:
@@ -1657,14 +1657,6 @@ packages:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
     engines: {node: '>=14.19.0'}
 
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.10:
-    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.12:
     resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
@@ -2506,7 +2498,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.2.4
       '@tailwindcss/oxide': 4.2.4
-      postcss: 8.5.10
+      postcss: 8.5.12
       tailwindcss: 4.2.4
 
   '@tybys/wasm-util@0.10.1':
@@ -2900,7 +2892,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.23
       caniuse-lite: 1.0.30001791
-      postcss: 8.4.31
+      postcss: 8.5.12
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       styled-jsx: 5.1.6(react@19.2.5)
@@ -3002,18 +2994,6 @@ snapshots:
       pngjs: 7.0.0
 
   pngjs@7.0.0: {}
-
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.10:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.12:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,12 @@ importers:
       '@decoro/adapter-spec':
         specifier: workspace:^
         version: link:../../packages/adapter-spec
+      '@json-render/core':
+        specifier: 0.18.0
+        version: 0.18.0(zod@4.3.6)
+      '@json-render/react':
+        specifier: 0.18.0
+        version: 0.18.0(react@19.2.5)(zod@4.3.6)
       '@k8o/arte-odyssey':
         specifier: 7.0.1
         version: 7.0.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.2.4)(typescript@6.0.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,7 @@ catalog:
   '@types/react': 19.2.14
   '@types/react-dom': 19.2.3
   '@vitejs/plugin-react': 6.0.1
-  postcss: 8.5.10
+  postcss: 8.5.12
   react: 19.2.5
   react-dom: 19.2.5
   tailwindcss: 4.2.4
@@ -18,6 +18,12 @@ catalog:
 allowBuilds:
   esbuild: false
   sharp: false
+
+overrides:
+  # next@16.2.4 pulls postcss@8.4.31 transitively, which is vulnerable to
+  # GHSA-7fh5-64p2-3v2j (XSS via unescaped </style>). Force 8.5.10+ until
+  # Next.js bumps it upstream.
+  postcss: '>=8.5.10'
 
 verifyDepsBeforeRun: install
 


### PR DESCRIPTION
## Summary

End-to-end proof of the iframe preview path, no LLM yet. The home page hosts an iframe of \`/preview\` and pushes a hard-coded sample Spec (a Card containing a Button). The \`/preview\` route mounts \`json-render\`'s \`Renderer\` with the \`adapter-arte-odyssey\` registry — so a real ArteOdyssey Card and Button render inside the isolated style space described in ADR-006.

### Message envelope (\`apps/web/src/lib/preview-message.ts\`)

| Direction | Type | Payload |
|---|---|---|
| Iframe → parent | \`decoro:ready\` | none — sent on mount |
| Parent → iframe | \`decoro:spec\` | \`{ spec: Spec }\` |

- Parent waits for \`decoro:ready\` before posting any spec, so the message never arrives before the iframe's listener is attached.
- All messages share the \`decoro:\` prefix so unrelated \`postMessage\` traffic (devtools, extensions) filters out cleanly.
- Origin is verified on both ends against \`window.location.origin\`.

### Notes

- The iframe is for **style-space isolation only** (ADR-006), not for security sandboxing — both sides are first-party Decoro routes from the same Next.js app, so the HTML \`sandbox\` attribute is intentionally omitted (rationale inline next to the lint-disable).
- \`@json-render/core\` and \`@json-render/react\` were added to \`apps/web\` deps; the preview page consumes them directly.
- Hard-coded spec lives in \`src/lib/sample-spec.ts\`; M7 replaces it with the live LLM stream.

Closes #5

## Test plan

- [x] \`pnpm typecheck\` passes
- [x] \`pnpm check\` (fmt + lint) passes
- [x] \`next build\` succeeds; both \`/\` and \`/preview\` prerender static
- [x] \`pnpm dev\` boots; \`/\` and \`/preview\` return 200
- [ ] Visual: open \`localhost:3000\` and confirm an ArteOdyssey Card with a "Hello from the iframe" Button renders inside the iframe (parent has the chat placeholder on the left)