### PR TITLE
chore(ci): add GitHub Actions for lint, types, test, build

### DIFF
--- a/.github/composite-actions/install/action.yml
+++ b/.github/composite-actions/install/action.yml
@@ -1,0 +1,14 @@
+name: Install
+description: Set up mise (Node + pnpm) and install workspace dependencies
+
+runs:
+  using: composite
+  steps:
+    - name: Setup mise
+      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      with:
+        cache: true
+
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,81 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  lint:
+    name: Lint + Format
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install
+        uses: ./.github/composite-actions/install
+
+      - name: Run vp check
+        run: pnpm check
+
+  types:
+    name: TypeScript
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install
+        uses: ./.github/composite-actions/install
+
+      - name: Run typecheck
+        run: pnpm typecheck
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install
+        uses: ./.github/composite-actions/install
+
+      - name: Run tests
+        run: pnpm test
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install
+        uses: ./.github/composite-actions/install
+
+      - name: Build all workspaces
+        run: pnpm build


### PR DESCRIPTION
## Summary

Add CI for every PR to \`main\` and every push to \`main\`. Four parallel jobs:

| Job | Command |
|---|---|
| Lint + Format | \`pnpm check\` (oxfmt + oxlint via vp check) |
| TypeScript | \`pnpm typecheck\` (\`tsc --noEmit\` across workspaces) |
| Test | \`pnpm test\` (vitest under vite-plus) |
| Build | \`pnpm build\` (\`next build\` for apps/web; source-export packages skip) |

Shared install logic is a composite action so each job stays declarative — \`mise\` provisions Node + pnpm from \`mise.toml\`, then \`pnpm install --frozen-lockfile\` (catches lockfile drift in PRs).

Concurrency cancels superseded PR runs but never cancels main pushes. Permissions are minimal (\`contents: read\`). Action versions are commit-pinned.

## Test plan

- [x] All four jobs pass locally (\`pnpm install --frozen-lockfile\`, \`pnpm check\`, \`pnpm typecheck\`, \`pnpm test\`, \`pnpm build\`)
- [ ] First CI run on this PR is green (visible after the workflow appears)