### PR TITLE
feat: /api/generate streaming Spec via pluggable LLM provider (M6)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,13 @@
 # API key for the LLM provider selected in apps/web/decoro.config.ts.
 # Copy this file to apps/web/.env.local and fill in the one your config uses.
 #
-# Anthropic — obtain from https://console.anthropic.com/
+# Vercel AI Gateway (recommended — one key reaches every provider, free
+# monthly credit). Obtain from https://vercel.com/dashboard/ai-gateway
+AI_GATEWAY_API_KEY=
+#
+# Anthropic direct — obtain from https://console.anthropic.com/
 ANTHROPIC_API_KEY=
 #
-# Google Gemini — obtain from https://aistudio.google.com/apikey (free tier)
+# Google Gemini direct — obtain from https://aistudio.google.com/apikey
+# (free tier)
 GOOGLE_GENERATIVE_AI_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Anthropic API key used by the /api/generate route. Obtain one from
+# https://console.anthropic.com/ and copy this file to `apps/web/.env.local`
+# before running `pnpm dev`.
+ANTHROPIC_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,8 @@
-# Anthropic API key used by the /api/generate route. Obtain one from
-# https://console.anthropic.com/ and copy this file to `apps/web/.env.local`
-# before running `pnpm dev`.
+# API key for the LLM provider selected in apps/web/decoro.config.ts.
+# Copy this file to apps/web/.env.local and fill in the one your config uses.
+#
+# Anthropic — obtain from https://console.anthropic.com/
 ANTHROPIC_API_KEY=
+#
+# Google Gemini — obtain from https://aistudio.google.com/apikey (free tier)
+GOOGLE_GENERATIVE_AI_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ pnpm-debug.log*
 
 # Environment files
 .env*
+!.env.example
 *.local
 
 # TypeScript

--- a/apps/web/decoro.config.ts
+++ b/apps/web/decoro.config.ts
@@ -35,7 +35,7 @@ import type { LlmConfig } from '@decoro/llm-config';
  * motivate the abstraction (per ADR-004).
  */
 export const llm: LlmConfig = {
-  provider: 'gateway',
-  model: 'anthropic/claude-sonnet-4-6',
-  apiKey: process.env['AI_GATEWAY_API_KEY'],
+  provider: 'google',
+  model: 'gemini-2.5-flash',
+  apiKey: process.env['GOOGLE_GENERATIVE_AI_API_KEY'],
 };

--- a/apps/web/decoro.config.ts
+++ b/apps/web/decoro.config.ts
@@ -13,14 +13,19 @@ import type { LlmConfig } from '@decoro/llm-config';
  *      wiring when this file is consumed from `apps/web` server code.
  *
  * Switching providers is a one-line change. The library design hypothesis
- * (ADR-003) is verified primarily on Anthropic Claude — Google Gemini is
- * wired so contributors without an Anthropic key can still smoke-test.
+ * (ADR-003) is verified primarily on Anthropic Claude — the other branches
+ * are wired so contributors can smoke-test without an Anthropic key.
  *
- * Anthropic (default):
+ * Vercel AI Gateway (default — free monthly credit, one key reaches every
+ * provider, lowest setup friction):
+ *   { provider: 'gateway', model: 'anthropic/claude-sonnet-4-6',
+ *     apiKey: process.env['AI_GATEWAY_API_KEY'] }
+ *
+ * Anthropic direct:
  *   { provider: 'anthropic', model: 'claude-sonnet-4-6',
  *     apiKey: process.env['ANTHROPIC_API_KEY'] }
  *
- * Google Gemini (free tier):
+ * Google Gemini direct (free tier):
  *   { provider: 'google', model: 'gemini-2.5-flash',
  *     apiKey: process.env['GOOGLE_GENERATIVE_AI_API_KEY'] }
  *
@@ -30,7 +35,7 @@ import type { LlmConfig } from '@decoro/llm-config';
  * motivate the abstraction (per ADR-004).
  */
 export const llm: LlmConfig = {
-  provider: 'anthropic',
-  model: 'claude-sonnet-4-6',
-  apiKey: process.env['ANTHROPIC_API_KEY'],
+  provider: 'gateway',
+  model: 'anthropic/claude-sonnet-4-6',
+  apiKey: process.env['AI_GATEWAY_API_KEY'],
 };

--- a/apps/web/decoro.config.ts
+++ b/apps/web/decoro.config.ts
@@ -1,0 +1,24 @@
+import type { LlmConfig } from '@decoro/llm-config';
+
+/**
+ * Decoro configuration. Edit this file to point Decoro at your preferred LLM
+ * provider and model. The API key is read from `ANTHROPIC_API_KEY` in the
+ * environment (see the repo-root `.env.example`); do not hard-code it here.
+ *
+ * Lives next to the Next.js app (rather than the repo root that
+ * `docs/architecture.md` originally sketched) for two practical reasons:
+ *   1. pnpm does not hoist workspace packages to the repo root, so a config at
+ *      the repo root cannot resolve `@decoro/llm-config`.
+ *   2. Next.js picks up `apps/web/.env.local` for the API key without extra
+ *      wiring when this file is consumed from `apps/web` server code.
+ *
+ * Adapter selection lives elsewhere for now — apps/web pins
+ * `@decoro/adapter-arte-odyssey` directly. A `defineConfig` helper that
+ * bundles adapter + LLM together can ship once we have a second adapter to
+ * motivate the abstraction (per ADR-004).
+ */
+export const llm: LlmConfig = {
+  provider: 'anthropic',
+  model: 'claude-sonnet-4-6',
+  apiKey: process.env['ANTHROPIC_API_KEY'],
+};

--- a/apps/web/decoro.config.ts
+++ b/apps/web/decoro.config.ts
@@ -2,8 +2,8 @@ import type { LlmConfig } from '@decoro/llm-config';
 
 /**
  * Decoro configuration. Edit this file to point Decoro at your preferred LLM
- * provider and model. The API key is read from `ANTHROPIC_API_KEY` in the
- * environment (see the repo-root `.env.example`); do not hard-code it here.
+ * provider and model. API keys are read from environment variables (see
+ * `.env.example` at the repo root); do not hard-code them here.
  *
  * Lives next to the Next.js app (rather than the repo root that
  * `docs/architecture.md` originally sketched) for two practical reasons:
@@ -11,6 +11,18 @@ import type { LlmConfig } from '@decoro/llm-config';
  *      the repo root cannot resolve `@decoro/llm-config`.
  *   2. Next.js picks up `apps/web/.env.local` for the API key without extra
  *      wiring when this file is consumed from `apps/web` server code.
+ *
+ * Switching providers is a one-line change. The library design hypothesis
+ * (ADR-003) is verified primarily on Anthropic Claude — Google Gemini is
+ * wired so contributors without an Anthropic key can still smoke-test.
+ *
+ * Anthropic (default):
+ *   { provider: 'anthropic', model: 'claude-sonnet-4-6',
+ *     apiKey: process.env['ANTHROPIC_API_KEY'] }
+ *
+ * Google Gemini (free tier):
+ *   { provider: 'google', model: 'gemini-2.5-flash',
+ *     apiKey: process.env['GOOGLE_GENERATIVE_AI_API_KEY'] }
  *
  * Adapter selection lives elsewhere for now — apps/web pins
  * `@decoro/adapter-arte-odyssey` directly. A `defineConfig` helper that

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,7 +1,11 @@
 import type { NextConfig } from 'next';
 
 const config: NextConfig = {
-  transpilePackages: ['@decoro/adapter-arte-odyssey', '@decoro/adapter-spec'],
+  transpilePackages: [
+    '@decoro/adapter-arte-odyssey',
+    '@decoro/adapter-spec',
+    '@decoro/llm-config',
+  ],
 };
 
 export default config;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,11 +12,14 @@
     "check:write": "vp check --fix"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "3.0.71",
     "@decoro/adapter-arte-odyssey": "workspace:^",
     "@decoro/adapter-spec": "workspace:^",
+    "@decoro/llm-config": "workspace:^",
     "@json-render/core": "0.18.0",
     "@json-render/react": "0.18.0",
     "@k8o/arte-odyssey": "7.0.1",
+    "ai": "6.0.168",
     "next": "16.2.4",
     "react": "catalog:",
     "react-dom": "catalog:",

--- a/apps/web/src/app/api-test/page.tsx
+++ b/apps/web/src/app/api-test/page.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { Button, Heading } from '@k8o/arte-odyssey';
+import { useState } from 'react';
+
+/**
+ * Throwaway smoke-test page for the /api/generate endpoint added in M6. Posts
+ * a short prompt, streams the response back, and dumps the raw JSONL stream
+ * plus the parsed Spec patches into the page so we can confirm the LLM is
+ * wired up before the proper chat UI lands in M7.
+ *
+ * Delete (or repurpose) once M7 ships.
+ */
+const ApiTestPage = () => {
+  const [prompt, setPrompt] = useState('Build a primary submit button');
+  const [log, setLog] = useState<string[]>([]);
+  const [busy, setBusy] = useState(false);
+
+  const append = (line: string) => {
+    setLog((prev) => [...prev, line]);
+  };
+
+  const run = async () => {
+    setLog([]);
+    setBusy(true);
+    try {
+      const res = await fetch('/api/generate', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ prompt }),
+      });
+      if (!res.ok || !res.body) {
+        append(`HTTP ${res.status.toString()}: ${await res.text()}`);
+        return;
+      }
+      // Async iteration over the byte stream is the canonical pattern; each
+      // chunk inherently waits for the previous one, so a sequential await
+      // here is intentional rather than a serialised parallel.
+      for await (const chunk of res.body.pipeThrough(new TextDecoderStream())) {
+        append(chunk);
+      }
+      append('--- stream complete ---');
+    } catch (err) {
+      append(`exception: ${(err as Error).message}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="bg-bg-base text-fg-base min-h-dvh space-y-4 p-6">
+      <Heading type="h1">/api/generate smoke test</Heading>
+      <textarea
+        value={prompt}
+        onChange={(e) => {
+          setPrompt(e.target.value);
+        }}
+        className="border-border-mute w-full rounded border p-2"
+        rows={3}
+      />
+      <Button onAction={run} disabled={busy}>
+        {busy ? 'Streaming…' : 'Generate'}
+      </Button>
+      <pre className="bg-bg-surface text-fg-mute max-h-96 overflow-auto rounded p-3 text-xs">
+        {log.join('') || '(no output yet)'}
+      </pre>
+    </div>
+  );
+};
+
+export default ApiTestPage;

--- a/apps/web/src/app/api/generate/route.ts
+++ b/apps/web/src/app/api/generate/route.ts
@@ -1,0 +1,44 @@
+import { arteOdysseyAdapter } from '@decoro/adapter-arte-odyssey';
+import { createModel } from '@decoro/llm-config';
+import type { Spec } from '@json-render/core';
+import { buildUserPrompt, pipeJsonRender } from '@json-render/core';
+import {
+  createUIMessageStream,
+  createUIMessageStreamResponse,
+  streamText,
+} from 'ai';
+
+import { llm } from '../../../../decoro.config.ts';
+
+type GenerateRequestBody = {
+  prompt: string;
+  currentSpec?: Spec | null;
+};
+
+const systemPrompt = [
+  arteOdysseyAdapter.catalog.prompt({ mode: 'standalone' }),
+  '',
+  'Library design principles:',
+  arteOdysseyAdapter.metadata.designPrinciples,
+].join('\n');
+
+export const POST = async (req: Request) => {
+  const body = (await req.json()) as GenerateRequestBody;
+
+  const result = streamText({
+    model: createModel(llm),
+    system: systemPrompt,
+    prompt: buildUserPrompt({
+      prompt: body.prompt,
+      currentSpec: body.currentSpec ?? undefined,
+    }),
+  });
+
+  const stream = createUIMessageStream({
+    execute: ({ writer }) => {
+      writer.merge(pipeJsonRender(result.toUIMessageStream()));
+    },
+  });
+
+  return createUIMessageStreamResponse({ stream });
+};

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -13,6 +13,7 @@
     "next-env.d.ts",
     "src/**/*.ts",
     "src/**/*.tsx",
+    "decoro.config.ts",
     ".next/types/**/*.ts"
   ],
   "exclude": ["node_modules", ".next"]

--- a/packages/llm-config/package.json
+++ b/packages/llm-config/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "3.0.71",
+    "@ai-sdk/gateway": "3.0.104",
     "@ai-sdk/google": "3.0.64",
     "ai": "6.0.168"
   }

--- a/packages/llm-config/package.json
+++ b/packages/llm-config/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@decoro/llm-config",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "check": "vp check",
+    "check:write": "vp check --fix"
+  },
+  "dependencies": {
+    "@ai-sdk/anthropic": "3.0.71",
+    "ai": "6.0.168"
+  }
+}

--- a/packages/llm-config/package.json
+++ b/packages/llm-config/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "3.0.71",
+    "@ai-sdk/google": "3.0.64",
     "ai": "6.0.168"
   }
 }

--- a/packages/llm-config/src/index.ts
+++ b/packages/llm-config/src/index.ts
@@ -1,4 +1,5 @@
 import { createAnthropic } from '@ai-sdk/anthropic';
+import { createGateway } from '@ai-sdk/gateway';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import type { LanguageModel } from 'ai';
 
@@ -12,10 +13,15 @@ import type { LanguageModel } from 'ai';
  *     (json-render structured output is strongest here).
  *   - `google` is wired so contributors without an Anthropic API key can
  *     still smoke-test on Gemini's free tier.
+ *   - `gateway` routes through Vercel AI Gateway — one key reaches every
+ *     supported provider (model strings look like `anthropic/...`,
+ *     `google/...`, `openai/...`). Vercel ships a free monthly credit, so
+ *     this is usually the lowest-friction path.
  */
 export type LlmConfig =
   | { provider: 'anthropic'; model: string; apiKey?: string }
-  | { provider: 'google'; model: string; apiKey?: string };
+  | { provider: 'google'; model: string; apiKey?: string }
+  | { provider: 'gateway'; model: string; apiKey?: string };
 
 /**
  * Resolve a config into an AI SDK model instance. Server-side only — never
@@ -31,6 +37,10 @@ export const createModel = (config: LlmConfig): LanguageModel => {
     case 'google': {
       const google = createGoogleGenerativeAI({ apiKey: config.apiKey });
       return google(config.model);
+    }
+    case 'gateway': {
+      const gateway = createGateway({ apiKey: config.apiKey });
+      return gateway(config.model);
     }
     default: {
       // Exhaustiveness guard. Adding a new provider must also add a case.

--- a/packages/llm-config/src/index.ts
+++ b/packages/llm-config/src/index.ts
@@ -1,0 +1,28 @@
+import { createAnthropic } from '@ai-sdk/anthropic';
+import type { LanguageModel } from 'ai';
+
+/**
+ * LLM configuration consumed by `createModel`. The shape is intentionally a
+ * discriminated union so adding `provider: 'google'` or `provider: 'openai'`
+ * later only adds branches — existing call sites stay exhaustive.
+ *
+ * MVP only verifies the `anthropic` branch end-to-end (per ADR-005).
+ */
+export type LlmConfig = {
+  provider: 'anthropic';
+  model: string;
+  apiKey?: string;
+};
+
+/**
+ * Resolve a config into an AI SDK model instance. Server-side only — never
+ * import this from client components, since the API key would leak into the
+ * client bundle.
+ *
+ * Single-branch today because `LlmConfig.provider` is a singleton union; the
+ * branch comes back as a switch when a second provider lands.
+ */
+export const createModel = (config: LlmConfig): LanguageModel => {
+  const anthropic = createAnthropic({ apiKey: config.apiKey });
+  return anthropic(config.model);
+};

--- a/packages/llm-config/src/index.ts
+++ b/packages/llm-config/src/index.ts
@@ -1,28 +1,43 @@
 import { createAnthropic } from '@ai-sdk/anthropic';
+import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import type { LanguageModel } from 'ai';
 
 /**
- * LLM configuration consumed by `createModel`. The shape is intentionally a
- * discriminated union so adding `provider: 'google'` or `provider: 'openai'`
- * later only adds branches — existing call sites stay exhaustive.
+ * LLM configuration consumed by `createModel`. The shape is a discriminated
+ * union so adding `provider: 'openai'` later only adds branches — existing
+ * call sites stay exhaustive.
  *
- * MVP only verifies the `anthropic` branch end-to-end (per ADR-005).
+ * MVP-time provider matrix (per ADR-005):
+ *   - `anthropic` is the verified target for the value-validation hypothesis
+ *     (json-render structured output is strongest here).
+ *   - `google` is wired so contributors without an Anthropic API key can
+ *     still smoke-test on Gemini's free tier.
  */
-export type LlmConfig = {
-  provider: 'anthropic';
-  model: string;
-  apiKey?: string;
-};
+export type LlmConfig =
+  | { provider: 'anthropic'; model: string; apiKey?: string }
+  | { provider: 'google'; model: string; apiKey?: string };
 
 /**
  * Resolve a config into an AI SDK model instance. Server-side only — never
  * import this from client components, since the API key would leak into the
  * client bundle.
- *
- * Single-branch today because `LlmConfig.provider` is a singleton union; the
- * branch comes back as a switch when a second provider lands.
  */
 export const createModel = (config: LlmConfig): LanguageModel => {
-  const anthropic = createAnthropic({ apiKey: config.apiKey });
-  return anthropic(config.model);
+  switch (config.provider) {
+    case 'anthropic': {
+      const anthropic = createAnthropic({ apiKey: config.apiKey });
+      return anthropic(config.model);
+    }
+    case 'google': {
+      const google = createGoogleGenerativeAI({ apiKey: config.apiKey });
+      return google(config.model);
+    }
+    default: {
+      // Exhaustiveness guard. Adding a new provider must also add a case.
+      const exhaustive: never = config;
+      throw new Error(
+        `Unsupported LLM provider: ${(exhaustive as LlmConfig).provider}`,
+      );
+    }
+  }
 };

--- a/packages/llm-config/tsconfig.json
+++ b/packages/llm-config/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,16 +61,22 @@ importers:
         version: 6.0.3
       vite-plus:
         specifier: 'catalog:'
-        version: 0.1.19(@types/node@24.12.2)(jiti@2.6.1)(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))
+        version: 0.1.19(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jiti@2.6.1)(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))
 
   apps/web:
     dependencies:
+      '@ai-sdk/anthropic':
+        specifier: 3.0.71
+        version: 3.0.71(zod@4.3.6)
       '@decoro/adapter-arte-odyssey':
         specifier: workspace:^
         version: link:../../packages/adapter-arte-odyssey
       '@decoro/adapter-spec':
         specifier: workspace:^
         version: link:../../packages/adapter-spec
+      '@decoro/llm-config':
+        specifier: workspace:^
+        version: link:../../packages/llm-config
       '@json-render/core':
         specifier: 0.18.0
         version: 0.18.0(zod@4.3.6)
@@ -80,9 +86,12 @@ importers:
       '@k8o/arte-odyssey':
         specifier: 7.0.1
         version: 7.0.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.2.4)(typescript@6.0.3)
+      ai:
+        specifier: 6.0.168
+        version: 6.0.168(zod@4.3.6)
       next:
         specifier: 16.2.4
-        version: 16.2.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 16.2.4(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react:
         specifier: 'catalog:'
         version: 19.2.5
@@ -149,7 +158,38 @@ importers:
         specifier: 0.18.0
         version: 0.18.0(zod@4.3.6)
 
+  packages/llm-config:
+    dependencies:
+      '@ai-sdk/anthropic':
+        specifier: 3.0.71
+        version: 3.0.71(zod@4.3.6)
+      ai:
+        specifier: 6.0.168
+        version: 6.0.168(zod@4.3.6)
+
 packages:
+
+  '@ai-sdk/anthropic@3.0.71':
+    resolution: {integrity: sha512-bUWOzrzR0gJKJO/PLGMR4uH2dqEgqGhrsCV+sSpk4KtOEnUQlfjZI/F7BFlqSvVpFbjdgYRRLysAeEZpJ6S1lg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/gateway@3.0.104':
+    resolution: {integrity: sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.23':
+    resolution: {integrity: sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@3.0.8':
+    resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
+    engines: {node: '>=18'}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -547,6 +587,10 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
 
   '@oxc-project/runtime@0.126.0':
     resolution: {integrity: sha512-oksjxfqDNmIYMGlIgLzYgnz5YjZax27RtQezsPpKEGo9AC5LOaIGHsivCCeaAWdCtPnRyjZXM/7svreCC8kZVQ==}
@@ -1069,6 +1113,10 @@ packages:
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
   '@vitejs/plugin-react@6.0.1':
     resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1225,6 +1273,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  ai@6.0.168:
+    resolution: {integrity: sha512-2HqCJuO+1V2aV7vfYs5LFEUfxbkGX+5oa54q/gCCTL7KLTdbxcCu5D7TdLA5kwsrs3Szgjah9q6D9tpjHM3hUQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
@@ -1344,6 +1398,10 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -1436,6 +1494,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -1859,6 +1920,30 @@ packages:
 
 snapshots:
 
+  '@ai-sdk/anthropic@3.0.71(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
+      zod: 4.3.6
+
+  '@ai-sdk/gateway@3.0.104(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
+      '@vercel/oidc': 3.2.0
+      zod: 4.3.6
+
+  '@ai-sdk/provider-utils@4.0.23(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 4.3.6
+
+  '@ai-sdk/provider@3.0.8':
+    dependencies:
+      json-schema: 0.4.0
+
   '@alloc/quick-lru@5.2.0': {}
 
   '@babel/code-frame@7.29.0':
@@ -2225,6 +2310,8 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.2.4':
     optional: true
 
+  '@opentelemetry/api@1.9.0': {}
+
   '@oxc-project/runtime@0.126.0': {}
 
   '@oxc-project/types@0.126.0': {}
@@ -2527,6 +2614,8 @@ snapshots:
 
   '@types/trusted-types@2.0.7': {}
 
+  '@vercel/oidc@3.2.0': {}
+
   '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
@@ -2562,7 +2651,7 @@ snapshots:
   '@voidzero-dev/vite-plus-linux-x64-musl@0.1.19':
     optional: true
 
-  '@voidzero-dev/vite-plus-test@0.1.19(@types/node@24.12.2)(jiti@2.6.1)(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))':
+  '@voidzero-dev/vite-plus-test@0.1.19(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jiti@2.6.1)(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
@@ -2579,6 +2668,7 @@ snapshots:
       vite: 8.0.10(@types/node@24.12.2)(jiti@2.6.1)
       ws: 8.20.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.0
       '@types/node': 24.12.2
     transitivePeerDependencies:
       - '@arethetypeswrong/core'
@@ -2606,6 +2696,14 @@ snapshots:
 
   '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.19':
     optional: true
+
+  ai@6.0.168(zod@4.3.6):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.104(zod@4.3.6)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.3.6
 
   ajv@8.20.0:
     dependencies:
@@ -2712,6 +2810,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  eventsource-parser@3.0.8: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-uri@3.1.0: {}
@@ -2776,6 +2876,8 @@ snapshots:
   json-parse-even-better-errors@2.3.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema@0.4.0: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -2886,7 +2988,7 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  next@16.2.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  next@16.2.4(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@next/env': 16.2.4
       '@swc/helpers': 0.5.15
@@ -2905,6 +3007,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.4
       '@next/swc-win32-arm64-msvc': 16.2.4
       '@next/swc-win32-x64-msvc': 16.2.4
+      '@opentelemetry/api': 1.9.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -3125,11 +3228,11 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  vite-plus@0.1.19(@types/node@24.12.2)(jiti@2.6.1)(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1)):
+  vite-plus@0.1.19(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jiti@2.6.1)(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1)):
     dependencies:
       '@oxc-project/types': 0.126.0
       '@voidzero-dev/vite-plus-core': 0.1.19(@types/node@24.12.2)(jiti@2.6.1)(typescript@6.0.3)
-      '@voidzero-dev/vite-plus-test': 0.1.19(@types/node@24.12.2)(jiti@2.6.1)(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))
+      '@voidzero-dev/vite-plus-test': 0.1.19(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jiti@2.6.1)(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))
       oxfmt: 0.45.0
       oxlint: 1.60.0(oxlint-tsgolint@0.21.1)
       oxlint-tsgolint: 0.21.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,6 +163,9 @@ importers:
       '@ai-sdk/anthropic':
         specifier: 3.0.71
         version: 3.0.71(zod@4.3.6)
+      '@ai-sdk/google':
+        specifier: 3.0.64
+        version: 3.0.64(zod@4.3.6)
       ai:
         specifier: 6.0.168
         version: 6.0.168(zod@4.3.6)
@@ -177,6 +180,12 @@ packages:
 
   '@ai-sdk/gateway@3.0.104':
     resolution: {integrity: sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/google@3.0.64':
+    resolution: {integrity: sha512-CbR82EgGPNrj/6q0HtclwuCqe0/pDShyv3nWDP/A9DroujzWXnLMlUJVrgPOsg4b40zQCwwVs2XSKCxvt/4QaA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -1931,6 +1940,12 @@ snapshots:
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
       '@vercel/oidc': 3.2.0
+      zod: 4.3.6
+
+  '@ai-sdk/google@3.0.64(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
       zod: 4.3.6
 
   '@ai-sdk/provider-utils@4.0.23(zod@4.3.6)':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,6 +163,9 @@ importers:
       '@ai-sdk/anthropic':
         specifier: 3.0.71
         version: 3.0.71(zod@4.3.6)
+      '@ai-sdk/gateway':
+        specifier: 3.0.104
+        version: 3.0.104(zod@4.3.6)
       '@ai-sdk/google':
         specifier: 3.0.64
         version: 3.0.64(zod@4.3.6)


### PR DESCRIPTION
## Summary

Stand up the LLM call path so the rest of the MVP has something to talk to. End-to-end verified live against Google Gemini.

### \`packages/llm-config\`

\`createModel(LlmConfig)\` returns an AI SDK \`LanguageModel\`. \`LlmConfig\` is a discriminated union over three provider branches — same shape, different SDK behind it — so swapping providers is a one-line edit in \`decoro.config.ts\`.

| Provider | Model field | Env var | Notes |
|---|---|---|---|
| \`anthropic\` | e.g. \`claude-sonnet-4-6\` | \`ANTHROPIC_API_KEY\` | The hypothesis-validation target per ADR-003. Pay-as-you-go via console.anthropic.com. |
| \`google\` | e.g. \`gemini-2.5-flash\` | \`GOOGLE_GENERATIVE_AI_API_KEY\` | Free tier from Google AI Studio. **Current default** so the local maintainer can verify without paying. |
| \`gateway\` | e.g. \`anthropic/claude-sonnet-4-6\` | \`AI_GATEWAY_API_KEY\` | Vercel AI Gateway — one key reaches every underlying provider, monthly free credit. |

Server-side only — never imported from client components, since the API key would leak into the bundle.

### \`apps/web/decoro.config.ts\`

The user-edited config file. Lives next to the Next.js app rather than at the repo root that \`docs/architecture.md\` originally sketched, because:

1. pnpm does not hoist workspace packages to the repo root, so a config there cannot resolve \`@decoro/llm-config\`.
2. Next.js picks up \`apps/web/.env.local\` automatically when consumed from \`apps/web\` server code.

The file's docstring shows ready-made config blocks for all three providers; flipping is a one-line edit. \`.env.example\` lists every env var with its console URL.

### \`apps/web/src/app/api/generate/route.ts\`

POST endpoint streams a json-render Spec via the canonical pattern:

- \`catalog.prompt({ mode: 'standalone' })\` builds the system message
- \`buildUserPrompt({ prompt, currentSpec })\` builds the user message
- AI SDK \`streamText\` produces the model output stream
- \`pipeJsonRender\` extracts the spec patch stream
- \`createUIMessageStream\` / \`createUIMessageStreamResponse\` wrap it for the client

### \`apps/web/src/app/api-test/page.tsx\`

Throwaway smoke-test page. Posts a prompt to \`/api/generate\` and dumps the raw stream into a \`<pre>\` so we can confirm wiring end-to-end before the real chat UI lands in M7. Replaces or is deleted by M7.

Closes #6

## Test plan

- [x] \`pnpm install\` succeeds
- [x] \`pnpm typecheck\` / \`pnpm check\` / \`pnpm test\` pass
- [x] \`next build\` prerenders \`/\`, \`/preview\`, \`/api-test\` static and \`/api/generate\` dynamic
- [x] **Live verification on Gemini**: with \`GOOGLE_GENERATIVE_AI_API_KEY\` in \`apps/web/.env.local\`, posting \`build a primary submit button\` to \`/api/generate\` streams a valid json-render Spec in ~3s — \`add /root\` then \`add /elements/...\` with a Button whose props (\`label\`, \`color\`, \`type\`) all come from the M3 catalog
- [ ] Live verification on Anthropic / AI Gateway is left unchecked here — same code path, different env var; whoever has those keys can run the same smoke check

## Notes

- AI SDK pinned: \`ai@6.0.168\`, \`@ai-sdk/anthropic@3.0.71\`, \`@ai-sdk/google@3.0.64\`, \`@ai-sdk/gateway@3.0.104\` — the newest versions older than the workspace \`minimumReleaseAge\` (3 days)
- \`.gitignore\` now allows \`.env.example\` through (\`.env*\` still blocks every real env file)
- \`next.config.ts\` \`transpilePackages\` adds \`@decoro/llm-config\`