### PR TITLE
feat: emit TSX from spec and show it under preview (M9)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,13 +16,14 @@
     "@decoro/adapter-arte-odyssey": "workspace:^",
     "@decoro/adapter-spec": "workspace:^",
     "@decoro/llm-config": "workspace:^",
-    "@json-render/core": "0.18.0",
-    "@json-render/react": "0.18.0",
-    "@k8o/arte-odyssey": "7.0.1",
+    "@json-render/core": "catalog:",
+    "@json-render/react": "catalog:",
+    "@k8o/arte-odyssey": "catalog:",
     "ai": "6.0.168",
     "next": "16.2.4",
     "react": "catalog:",
     "react-dom": "catalog:",
+    "shiki": "catalog:",
     "tailwindcss": "catalog:"
   },
   "devDependencies": {

--- a/apps/web/src/components/code-panel.tsx
+++ b/apps/web/src/components/code-panel.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { arteOdysseyAdapter } from '@decoro/adapter-arte-odyssey';
+import type { Spec } from '@json-render/core';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { codeToHtml } from 'shiki';
+
+type Props = {
+  spec: Spec | null;
+};
+
+const PLACEHOLDER = 'Generated TSX appears here.';
+
+/**
+ * Renders the current Spec as TSX, syntax-highlighted with Shiki. Updates
+ * incrementally as the spec changes. M10 will add the copy-to-clipboard
+ * button.
+ */
+export const CodePanel = ({ spec }: Props) => {
+  const code = useMemo(
+    () => (spec ? arteOdysseyAdapter.codeOutput.generate(spec) : ''),
+    [spec],
+  );
+  const [html, setHtml] = useState('');
+
+  const generationRef = useRef(0);
+  useEffect(() => {
+    if (code === '') {
+      setHtml('');
+      return;
+    }
+    const generation = ++generationRef.current;
+    void (async () => {
+      const result = await codeToHtml(code, {
+        lang: 'tsx',
+        theme: 'github-light',
+      });
+      if (generation === generationRef.current) setHtml(result);
+    })();
+  }, [code]);
+
+  if (code === '') {
+    return <p className="text-fg-mute p-4 text-sm">{PLACEHOLDER}</p>;
+  }
+
+  // Shiki output is HTML we generated ourselves from a string we generated
+  // ourselves; it never contains user-controlled content. Disabling
+  // dangerouslySetInnerHTML's lint here is the canonical Shiki integration.
+  return (
+    <div
+      className="text-sm [&_pre]:overflow-auto [&_pre]:p-4"
+      // oxlint-disable-next-line eslint(react/no-danger)
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+};

--- a/apps/web/src/components/home-shell.tsx
+++ b/apps/web/src/components/home-shell.tsx
@@ -4,12 +4,16 @@ import { Heading } from '@k8o/arte-odyssey';
 
 import { useDecoroChat } from '../lib/use-decoro-chat.ts';
 import { type ChatMessage, ChatPane } from './chat-pane.tsx';
+import { CodePanel } from './code-panel.tsx';
 import { PreviewFrame } from './preview-frame.tsx';
 
 /**
  * Top-level client shell for `/`. Wires the chat pane to `useDecoroChat`,
  * which posts `{ messages, currentSpec }` to /api/generate so each follow-up
  * iterates on the existing spec instead of regenerating from scratch (M8).
+ *
+ * The right pane is split vertically: live preview (top) and the generated
+ * TSX (bottom, M9). Both update on every spec patch.
  */
 export const HomeShell = () => {
   const { messages, spec, isStreaming, error, send } = useDecoroChat({
@@ -50,6 +54,12 @@ export const HomeShell = () => {
           </div>
           <div className="flex-1 overflow-hidden">
             <PreviewFrame spec={spec} />
+          </div>
+          <div className="border-border-mute border-t px-6 py-4">
+            <Heading type="h2">Code</Heading>
+          </div>
+          <div className="bg-bg-surface h-1/3 overflow-auto">
+            <CodePanel spec={spec} />
           </div>
         </section>
       </div>

--- a/packages/adapter-arte-odyssey/package.json
+++ b/packages/adapter-arte-odyssey/package.json
@@ -14,9 +14,10 @@
   },
   "dependencies": {
     "@decoro/adapter-spec": "workspace:^",
-    "@json-render/core": "0.18.0",
-    "@json-render/react": "0.18.0",
-    "@k8o/arte-odyssey": "7.0.1",
+    "@json-render/codegen": "catalog:",
+    "@json-render/core": "catalog:",
+    "@json-render/react": "catalog:",
+    "@k8o/arte-odyssey": "catalog:",
     "react": "catalog:",
     "zod": "4.3.6"
   },

--- a/packages/adapter-arte-odyssey/src/adapter.test.tsx
+++ b/packages/adapter-arte-odyssey/src/adapter.test.tsx
@@ -57,9 +57,33 @@ describe('adapter-arte-odyssey', () => {
     expect(tsx).toContain('export const GeneratedComponent');
     expect(tsx).toContain('<Card appearance="shadow">');
     expect(tsx).toContain(
-      '<Button color="primary" variant="contained">Save</Button>',
+      '<Button color="primary" variant="contained">{"Save"}</Button>',
     );
     expect(tsx).toContain('</Card>');
+  });
+
+  it('escapes JSX-significant characters in Button labels', () => {
+    const tsx = arteOdysseyAdapter.codeOutput.generate({
+      root: 'btn',
+      elements: {
+        btn: {
+          type: 'Button',
+          props: {
+            label: 'Save & Close <"now">',
+            color: null,
+            variant: null,
+            type: null,
+            size: null,
+            fullWidth: null,
+            disabled: null,
+          },
+          children: [],
+        },
+      },
+    });
+    // Wrapped in a JSX expression with a JS string literal — valid TSX even
+    // though the label contains `<`, `&`, `>`, and quotes.
+    expect(tsx).toContain('<Button>{"Save & Close <\\"now\\">"}</Button>');
   });
 
   it('renders Card via the registry', () => {

--- a/packages/adapter-arte-odyssey/src/adapter.test.tsx
+++ b/packages/adapter-arte-odyssey/src/adapter.test.tsx
@@ -23,6 +23,45 @@ describe('adapter-arte-odyssey', () => {
     expect(arteOdysseyAdapter.codeOutput.importPath).toBe('@k8o/arte-odyssey');
   });
 
+  it('generates empty string for an empty spec', () => {
+    expect(
+      arteOdysseyAdapter.codeOutput.generate({ root: '', elements: {} }),
+    ).toBe('');
+  });
+
+  it('generates valid TSX for a Card containing a Button', () => {
+    const tsx = arteOdysseyAdapter.codeOutput.generate({
+      root: 'card-1',
+      elements: {
+        'card-1': {
+          type: 'Card',
+          props: { appearance: 'shadow' },
+          children: ['btn-1'],
+        },
+        'btn-1': {
+          type: 'Button',
+          props: {
+            label: 'Save',
+            color: 'primary',
+            variant: 'contained',
+            type: null,
+            size: null,
+            fullWidth: null,
+            disabled: null,
+          },
+          children: [],
+        },
+      },
+    });
+    expect(tsx).toContain("import { Button, Card } from '@k8o/arte-odyssey';");
+    expect(tsx).toContain('export const GeneratedComponent');
+    expect(tsx).toContain('<Card appearance="shadow">');
+    expect(tsx).toContain(
+      '<Button color="primary" variant="contained">Save</Button>',
+    );
+    expect(tsx).toContain('</Card>');
+  });
+
   it('renders Card via the registry', () => {
     const CardRenderer = arteOdysseyAdapter.registry['Card']!;
     const html = renderToStaticMarkup(

--- a/packages/adapter-arte-odyssey/src/code-output.ts
+++ b/packages/adapter-arte-odyssey/src/code-output.ts
@@ -34,8 +34,14 @@ const formatters: Record<string, Formatter> = {
     } & Record<string, unknown>;
     const propsAttrs = serializeProps(stripNullish(rest), { quotes: 'double' });
     const open = propsAttrs ? `<Button ${propsAttrs}>` : '<Button>';
+    // Wrap the label in a JSX expression containing a JS string literal so
+    // labels with JSX-significant characters (`<`, `>`, `&`, `{`, `}`,
+    // quotes) emit valid TSX. React escapes these in the preview path, but
+    // the textual output that ends up in the user's codebase has to be safe
+    // on its own. JSON.stringify is the simplest canonical "JS string
+    // literal" formatter.
     const labelText = typeof label === 'string' ? label : '';
-    return `${pad(depth)}${open}${labelText}</Button>`;
+    return `${pad(depth)}${open}{${JSON.stringify(labelText)}}</Button>`;
   },
   Card: (element, renderedChildren, depth) => {
     const propsAttrs = serializeProps(stripNullish(element.props), {

--- a/packages/adapter-arte-odyssey/src/code-output.ts
+++ b/packages/adapter-arte-odyssey/src/code-output.ts
@@ -1,5 +1,92 @@
 import type { AdapterCodeOutput } from '@decoro/adapter-spec';
+import { collectUsedComponents, serializeProps } from '@json-render/codegen';
+import type { Spec, UIElement } from '@json-render/core';
+
+const importPath = '@k8o/arte-odyssey';
+
+const indentUnit = '  ';
+const pad = (depth: number) => indentUnit.repeat(depth);
+
+const stripNullish = (props: Record<string, unknown>) =>
+  Object.fromEntries(
+    Object.entries(props).filter(([, v]) => v !== null && v !== undefined),
+  );
+
+type Formatter = (
+  element: UIElement,
+  renderedChildren: string[],
+  depth: number,
+) => string;
+
+/**
+ * Per-component formatters. Each one knows the gap between the AI-facing
+ * Catalog shape (e.g. Button taking `label` as a prop) and the real
+ * ArteOdyssey component shape (Button taking children).
+ *
+ * When new components are added to the Catalog, add a matching formatter
+ * here — the codegen explicitly fails for unknown component types so the gap
+ * cannot be silently glossed over.
+ */
+const formatters: Record<string, Formatter> = {
+  Button: (element, _children, depth) => {
+    const { label, ...rest } = element.props as {
+      label?: unknown;
+    } & Record<string, unknown>;
+    const propsAttrs = serializeProps(stripNullish(rest), { quotes: 'double' });
+    const open = propsAttrs ? `<Button ${propsAttrs}>` : '<Button>';
+    const labelText = typeof label === 'string' ? label : '';
+    return `${pad(depth)}${open}${labelText}</Button>`;
+  },
+  Card: (element, renderedChildren, depth) => {
+    const propsAttrs = serializeProps(stripNullish(element.props), {
+      quotes: 'double',
+    });
+    if (renderedChildren.length === 0) {
+      return propsAttrs
+        ? `${pad(depth)}<Card ${propsAttrs} />`
+        : `${pad(depth)}<Card />`;
+    }
+    const open = propsAttrs ? `<Card ${propsAttrs}>` : '<Card>';
+    return [
+      `${pad(depth)}${open}`,
+      ...renderedChildren,
+      `${pad(depth)}</Card>`,
+    ].join('\n');
+  },
+};
+
+const renderElement = (spec: Spec, key: string, depth: number): string => {
+  const element = spec.elements[key];
+  if (!element) return '';
+  const formatter = formatters[element.type];
+  if (!formatter) {
+    throw new Error(
+      `adapter-arte-odyssey codegen: missing formatter for "${element.type}". Add an entry to formatters in code-output.ts.`,
+    );
+  }
+  const children = (element.children ?? [])
+    .map((childKey) => renderElement(spec, childKey, depth + 1))
+    .filter((s) => s !== '');
+  return formatter(element, children, depth);
+};
+
+const generate = (spec: Spec): string => {
+  if (spec.root === '' || !spec.elements[spec.root]) return '';
+  const used = [...collectUsedComponents(spec)].toSorted();
+  if (used.length === 0) return '';
+  const importLine = `import { ${used.join(', ')} } from '${importPath}';`;
+  const body = renderElement(spec, spec.root, 1);
+  return [
+    importLine,
+    '',
+    'export const GeneratedComponent = () => (',
+    body,
+    ');',
+    '',
+  ].join('\n');
+};
 
 export const codeOutput: AdapterCodeOutput = {
-  importPath: '@k8o/arte-odyssey',
+  importPath,
+  generate,
 };

--- a/packages/adapter-spec/package.json
+++ b/packages/adapter-spec/package.json
@@ -12,6 +12,6 @@
     "check:write": "vp check --fix"
   },
   "dependencies": {
-    "@json-render/core": "0.18.0"
+    "@json-render/core": "catalog:"
   }
 }

--- a/packages/adapter-spec/src/index.ts
+++ b/packages/adapter-spec/src/index.ts
@@ -1,4 +1,4 @@
-import type { Catalog } from '@json-render/core';
+import type { Catalog, Spec } from '@json-render/core';
 
 /**
  * Free-form description of the target component library, surfaced in the UI
@@ -22,12 +22,15 @@ export type AdapterRegistry<TComponent = unknown> = Record<string, TComponent>;
 /**
  * Hooks an adapter exposes for turning a `json-render` Spec into TSX.
  *
- * Loose by design — refined in M9 (`json-render` codegen wiring) once the
- * concrete needs are known. ADR-004: do not pre-abstract.
+ * - `importPath`: where the generated code imports components from (e.g.
+ *   `'@k8o/arte-odyssey'`).
+ * - `generate(spec)`: returns a single self-contained TSX string. Empty spec
+ *   yields `''`. Per-component formatting (e.g. mapping a `label` prop to
+ *   children for buttons) lives inside the adapter's implementation.
  */
 export type AdapterCodeOutput = {
-  /** Module path the generated TSX imports components from. */
   importPath: string;
+  generate: (spec: Spec) => string;
 };
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,18 @@ settings:
 
 catalogs:
   default:
+    '@json-render/codegen':
+      specifier: 0.18.0
+      version: 0.18.0
+    '@json-render/core':
+      specifier: 0.18.0
+      version: 0.18.0
+    '@json-render/react':
+      specifier: 0.18.0
+      version: 0.18.0
+    '@k8o/arte-odyssey':
+      specifier: 7.0.1
+      version: 7.0.1
     '@tailwindcss/postcss':
       specifier: 4.2.4
       version: 4.2.4
@@ -24,6 +36,9 @@ catalogs:
     react-dom:
       specifier: 19.2.5
       version: 19.2.5
+    shiki:
+      specifier: 4.0.2
+      version: 4.0.2
     tailwindcss:
       specifier: 4.2.4
       version: 4.2.4
@@ -78,13 +93,13 @@ importers:
         specifier: workspace:^
         version: link:../../packages/llm-config
       '@json-render/core':
-        specifier: 0.18.0
+        specifier: 'catalog:'
         version: 0.18.0(zod@4.3.6)
       '@json-render/react':
-        specifier: 0.18.0
+        specifier: 'catalog:'
         version: 0.18.0(react@19.2.5)(zod@4.3.6)
       '@k8o/arte-odyssey':
-        specifier: 7.0.1
+        specifier: 'catalog:'
         version: 7.0.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.2.4)(typescript@6.0.3)
       ai:
         specifier: 6.0.168
@@ -98,6 +113,9 @@ importers:
       react-dom:
         specifier: 'catalog:'
         version: 19.2.5(react@19.2.5)
+      shiki:
+        specifier: 'catalog:'
+        version: 4.0.2
       tailwindcss:
         specifier: 'catalog:'
         version: 4.2.4
@@ -123,14 +141,17 @@ importers:
       '@decoro/adapter-spec':
         specifier: workspace:^
         version: link:../adapter-spec
+      '@json-render/codegen':
+        specifier: 'catalog:'
+        version: 0.18.0(zod@4.3.6)
       '@json-render/core':
-        specifier: 0.18.0
+        specifier: 'catalog:'
         version: 0.18.0(zod@4.3.6)
       '@json-render/react':
-        specifier: 0.18.0
+        specifier: 'catalog:'
         version: 0.18.0(react@19.2.5)(zod@4.3.6)
       '@k8o/arte-odyssey':
-        specifier: 7.0.1
+        specifier: 'catalog:'
         version: 7.0.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.2.4)(typescript@6.0.3)
       react:
         specifier: 'catalog:'
@@ -155,7 +176,7 @@ importers:
   packages/adapter-spec:
     dependencies:
       '@json-render/core':
-        specifier: 0.18.0
+        specifier: 'catalog:'
         version: 0.18.0(zod@4.3.6)
 
   packages/llm-config:
@@ -494,6 +515,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@json-render/codegen@0.18.0':
+    resolution: {integrity: sha512-vEKiM02vD5Ux7B7HYY1UrVBPuP1ntTBvJsuXKwm2qTgzYiseoVi8nTQRxqmeQnXsVaW6f4pP2drQCKKMJa3ItA==}
 
   '@json-render/core@0.18.0':
     resolution: {integrity: sha512-zm0K9cgxZLGshw5TmdKe3Xc6fpjbONdlj3v+Er+HhCYZ9fSJpv32d9VzQds4bDW36vPfdieAOcsPR9+EcTff7Q==}
@@ -996,6 +1020,37 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
 
+  '@shikijs/core@4.0.2':
+    resolution: {integrity: sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-javascript@4.0.2':
+    resolution: {integrity: sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-oniguruma@4.0.2':
+    resolution: {integrity: sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/langs@4.0.2':
+    resolution: {integrity: sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/primitive@4.0.2':
+    resolution: {integrity: sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==}
+    engines: {node: '>=20'}
+
+  '@shikijs/themes@4.0.2':
+    resolution: {integrity: sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==}
+    engines: {node: '>=20'}
+
+  '@shikijs/types@4.0.2':
+    resolution: {integrity: sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
   '@simple-libs/child-process-utils@1.0.2':
     resolution: {integrity: sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==}
     engines: {node: '>=18'}
@@ -1111,6 +1166,12 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
 
@@ -1124,6 +1185,12 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
@@ -1327,6 +1394,15 @@ packages:
   caniuse-lite@1.0.30001791:
     resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
@@ -1344,6 +1420,9 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
@@ -1381,9 +1460,16 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
@@ -1463,6 +1549,15 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -1622,9 +1717,27 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
   meow@13.2.0:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
     engines: {node: '>=18'}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -1682,6 +1795,12 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  oniguruma-parser@0.12.2:
+    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
+
+  oniguruma-to-es@4.3.6:
+    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
+
   oxfmt@0.45.0:
     resolution: {integrity: sha512-0o/COoN9fY50bjVeM7PQsNgbhndKurBIeTIcspW033OumksjJJmIVDKjAk5HMwU/GHTxSOdGDdhJ6BRzGPmsHg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1734,6 +1853,9 @@ packages:
     resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
   react-dom@19.2.5:
     resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
     peerDependencies:
@@ -1742,6 +1864,15 @@ packages:
   react@19.2.5:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
+
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -1776,6 +1907,10 @@ packages:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
+  shiki@4.0.2:
+    resolution: {integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==}
+    engines: {node: '>=20'}
+
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
@@ -1784,12 +1919,18 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -1840,6 +1981,9 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -1850,6 +1994,27 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite-plus@0.1.19:
     resolution: {integrity: sha512-QWuTqkO/a8Q7I3hHnYdvwlJa7mcc6hgh99/8CHoRb27pgo+z1ux+NGYYCZPJHKVtatAtVRaQQvy4cEQBHyB87A==}
@@ -1929,6 +2094,9 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -2251,6 +2419,12 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@json-render/codegen@0.18.0(zod@4.3.6)':
+    dependencies:
+      '@json-render/core': 0.18.0(zod@4.3.6)
+    transitivePeerDependencies:
+      - zod
+
   '@json-render/core@0.18.0(zod@4.3.6)':
     dependencies:
       zod: 4.3.6
@@ -2525,6 +2699,46 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
+  '@shikijs/core@4.0.2':
+    dependencies:
+      '@shikijs/primitive': 4.0.2
+      '@shikijs/types': 4.0.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@4.0.2':
+    dependencies:
+      '@shikijs/types': 4.0.2
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.6
+
+  '@shikijs/engine-oniguruma@4.0.2':
+    dependencies:
+      '@shikijs/types': 4.0.2
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@4.0.2':
+    dependencies:
+      '@shikijs/types': 4.0.2
+
+  '@shikijs/primitive@4.0.2':
+    dependencies:
+      '@shikijs/types': 4.0.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/themes@4.0.2':
+    dependencies:
+      '@shikijs/types': 4.0.2
+
+  '@shikijs/types@4.0.2':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
   '@simple-libs/child-process-utils@1.0.2':
     dependencies:
       '@simple-libs/stream-utils': 1.2.0
@@ -2618,6 +2832,14 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/node@24.12.2':
     dependencies:
       undici-types: 7.16.0
@@ -2631,6 +2853,10 @@ snapshots:
       csstype: 3.2.3
 
   '@types/trusted-types@2.0.7': {}
+
+  '@types/unist@3.0.3': {}
+
+  '@ungap/structured-clone@1.3.0': {}
 
   '@vercel/oidc@3.2.0': {}
 
@@ -2753,6 +2979,12 @@ snapshots:
 
   caniuse-lite@1.0.30001791: {}
 
+  ccount@2.0.1: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
   client-only@0.0.1: {}
 
   cliui@8.0.1:
@@ -2768,6 +3000,8 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  comma-separated-tokens@2.0.3: {}
 
   compare-func@2.0.0:
     dependencies:
@@ -2805,7 +3039,13 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   dot-prop@5.3.0:
     dependencies:
@@ -2865,6 +3105,26 @@ snapshots:
       ini: 6.0.0
 
   graceful-fs@4.2.11: {}
+
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  html-void-elements@3.0.0: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -2984,7 +3244,36 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
   meow@13.2.0: {}
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
 
   minimist@1.2.8: {}
 
@@ -3032,6 +3321,14 @@ snapshots:
       - babel-plugin-macros
 
   obug@2.1.1: {}
+
+  oniguruma-parser@0.12.2: {}
+
+  oniguruma-to-es@4.3.6:
+    dependencies:
+      oniguruma-parser: 0.12.2
+      regex: 6.1.0
+      regex-recursion: 6.0.2
 
   oxfmt@0.45.0:
     dependencies:
@@ -3122,12 +3419,24 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  property-information@7.1.0: {}
+
   react-dom@19.2.5(react@19.2.5):
     dependencies:
       react: 19.2.5
       scheduler: 0.27.0
 
   react@19.2.5: {}
+
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
 
   require-directory@2.1.1: {}
 
@@ -3194,6 +3503,17 @@ snapshots:
       '@img/sharp-win32-x64': 0.34.5
     optional: true
 
+  shiki@4.0.2:
+    dependencies:
+      '@shikijs/core': 4.0.2
+      '@shikijs/engine-javascript': 4.0.2
+      '@shikijs/engine-oniguruma': 4.0.2
+      '@shikijs/langs': 4.0.2
+      '@shikijs/themes': 4.0.2
+      '@shikijs/types': 4.0.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
   sirv@3.0.2:
     dependencies:
       '@polka/url': 1.0.0-next.29
@@ -3202,6 +3522,8 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
   std-env@4.1.0: {}
 
   string-width@4.2.3:
@@ -3209,6 +3531,11 @@ snapshots:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
 
   strip-ansi@6.0.1:
     dependencies:
@@ -3240,11 +3567,46 @@ snapshots:
 
   totalist@3.0.1: {}
 
+  trim-lines@3.0.1: {}
+
   tslib@2.8.1: {}
 
   typescript@6.0.3: {}
 
   undici-types@7.16.0: {}
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite-plus@0.1.19(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jiti@2.6.1)(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1)):
     dependencies:
@@ -3328,3 +3690,5 @@ snapshots:
       yargs-parser: 21.1.1
 
   zod@4.3.6: {}
+
+  zwitch@2.0.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,10 @@ packages:
 blockExoticSubdeps: true
 
 catalog:
+  '@json-render/codegen': 0.18.0
+  '@json-render/core': 0.18.0
+  '@json-render/react': 0.18.0
+  '@k8o/arte-odyssey': 7.0.1
   '@tailwindcss/postcss': 4.2.4
   '@types/react': 19.2.14
   '@types/react-dom': 19.2.3
@@ -12,6 +16,7 @@ catalog:
   postcss: 8.5.12
   react: 19.2.5
   react-dom: 19.2.5
+  shiki: 4.0.2
   tailwindcss: 4.2.4
   vite-plus: 0.1.19
 


### PR DESCRIPTION
## Summary

The right pane now splits vertically: live ArteOdyssey preview on top, generated TSX with Shiki syntax highlighting on bottom. Both update on every spec patch.

### \`adapter-spec\`

\`AdapterCodeOutput\` grows a \`generate(spec): string\` field, so the contract now covers both "where do generated imports point" (\`importPath\`) and "how do I lower a Spec to TSX" (\`generate\`).

### \`adapter-arte-odyssey\`

Implements \`generate\` with \`@json-render/codegen\` building blocks (\`collectUsedComponents\` + \`serializeProps\`). Per-component formatters live in a small registry:
- **Button** bridges the catalog/runtime gap by lowering its \`label\` prop into JSX children.
- **Card** forwards props and recursively renders its child elements.
- Unknown component types **throw** — surfacing the gap is better than silently emitting broken JSX.

Tests cover empty spec, the import line, the wrapper export scaffold, and a Card+Button structure.

### \`apps/web\`

- \`CodePanel\` (client) calls the adapter's \`generate\` and highlights the result with Shiki (\`lang: tsx\`, \`theme: github-light\`). Re-runs on each spec change with a generation counter so stale highlight results are discarded.
- \`HomeShell\` splits the right pane: \`PreviewFrame\` on top, \`CodePanel\` on the bottom third with its own scroll region.

### Workspace catalog

\`@json-render/{core,react,codegen}\`, \`shiki\`, \`@k8o/arte-odyssey\` are now cataloged so version drift across packages is impossible.

Closes #9

## Test plan

- [x] \`pnpm typecheck\` / \`pnpm check\` / \`pnpm test\` (6/6) pass
- [x] **Live (Gemini 2.5 Flash)**: \`"a card with a primary submit button labeled Save inside"\` → Card with "Save" Button in the iframe **and** the matching TSX (\`import { Button, Card } from '@k8o/arte-odyssey';\` + \`export const GeneratedComponent\`) syntax-highlighted in the bottom pane (Shiki: 8 lines, 38 styled spans, GitHub-light theme colors).
- [ ] Acceptance stretch: copy the generated TSX into a separate React project that has \`@k8o/arte-odyssey\` installed and confirm it renders the same UI.