### PR TITLE
fix(codegen): degrade gracefully on malformed spec (Codex P1)

### DIFF
--- a/apps/web/src/components/code-panel.tsx
+++ b/apps/web/src/components/code-panel.tsx
@@ -11,27 +11,47 @@ type Props = {
 
 const PLACEHOLDER = 'Generated TSX appears here.';
 
+type CodeState =
+  | { kind: 'empty' }
+  | { kind: 'ok'; value: string }
+  | { kind: 'error'; message: string };
+
 /**
  * Renders the current Spec as TSX, syntax-highlighted with Shiki. Updates
  * incrementally as the spec changes. M10 will add the copy-to-clipboard
  * button.
+ *
+ * Streaming sometimes hands us an inconsistent intermediate spec — a child
+ * key that hasn't landed yet, an unknown component type, or (theoretically)
+ * a cycle. The adapter's `generate` throws in those cases; we catch here so
+ * the failure stays scoped to this panel and the live preview / chat keep
+ * running.
  */
 export const CodePanel = ({ spec }: Props) => {
-  const code = useMemo(
-    () => (spec ? arteOdysseyAdapter.codeOutput.generate(spec) : ''),
-    [spec],
-  );
+  const code = useMemo<CodeState>(() => {
+    if (spec === null) return { kind: 'empty' };
+    try {
+      const value = arteOdysseyAdapter.codeOutput.generate(spec);
+      return value === '' ? { kind: 'empty' } : { kind: 'ok', value };
+    } catch (err) {
+      return {
+        kind: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }, [spec]);
   const [html, setHtml] = useState('');
 
   const generationRef = useRef(0);
   useEffect(() => {
-    if (code === '') {
+    if (code.kind !== 'ok') {
       setHtml('');
       return;
     }
+    const source = code.value;
     const generation = ++generationRef.current;
     void (async () => {
-      const result = await codeToHtml(code, {
+      const result = await codeToHtml(source, {
         lang: 'tsx',
         theme: 'github-light',
       });
@@ -39,8 +59,15 @@ export const CodePanel = ({ spec }: Props) => {
     })();
   }, [code]);
 
-  if (code === '') {
+  if (code.kind === 'empty') {
     return <p className="text-fg-mute p-4 text-sm">{PLACEHOLDER}</p>;
+  }
+  if (code.kind === 'error') {
+    return (
+      <p className="text-fg-mute p-4 text-sm" role="alert">
+        Code generation paused: {code.message}
+      </p>
+    );
   }
 
   // Shiki output is HTML we generated ourselves from a string we generated

--- a/packages/adapter-arte-odyssey/src/adapter.test.tsx
+++ b/packages/adapter-arte-odyssey/src/adapter.test.tsx
@@ -62,6 +62,29 @@ describe('adapter-arte-odyssey', () => {
     expect(tsx).toContain('</Card>');
   });
 
+  it('throws on a spec containing an unknown component type', () => {
+    expect(() =>
+      arteOdysseyAdapter.codeOutput.generate({
+        root: 'unknown',
+        elements: {
+          unknown: { type: 'NotInCatalog', props: {}, children: [] },
+        },
+      }),
+    ).toThrow(/missing formatter for "NotInCatalog"/);
+  });
+
+  it('throws on a spec with a cycle in the children graph', () => {
+    expect(() =>
+      arteOdysseyAdapter.codeOutput.generate({
+        root: 'a',
+        elements: {
+          a: { type: 'Card', props: {}, children: ['b'] },
+          b: { type: 'Card', props: {}, children: ['a'] },
+        },
+      }),
+    ).toThrow(/cycle detected/);
+  });
+
   it('escapes JSX-significant characters in Button labels', () => {
     const tsx = arteOdysseyAdapter.codeOutput.generate({
       root: 'btn',

--- a/packages/adapter-arte-odyssey/src/code-output.ts
+++ b/packages/adapter-arte-odyssey/src/code-output.ts
@@ -1,5 +1,5 @@
 import type { AdapterCodeOutput } from '@decoro/adapter-spec';
-import { collectUsedComponents, serializeProps } from '@json-render/codegen';
+import { serializeProps } from '@json-render/codegen';
 import type { Spec, UIElement } from '@json-render/core';
 
 const importPath = '@k8o/arte-odyssey';
@@ -61,7 +61,25 @@ const formatters: Record<string, Formatter> = {
   },
 };
 
-const renderElement = (spec: Spec, key: string, depth: number): string => {
+const MAX_DEPTH = 64;
+
+const renderElement = (
+  spec: Spec,
+  key: string,
+  depth: number,
+  visiting: Set<string>,
+  usedTypes: Set<string>,
+): string => {
+  if (depth > MAX_DEPTH) {
+    throw new Error(
+      `adapter-arte-odyssey codegen: spec exceeds max depth ${MAX_DEPTH.toString()}.`,
+    );
+  }
+  if (visiting.has(key)) {
+    throw new Error(
+      `adapter-arte-odyssey codegen: cycle detected at element "${key}".`,
+    );
+  }
   const element = spec.elements[key];
   if (!element) return '';
   const formatter = formatters[element.type];
@@ -70,18 +88,27 @@ const renderElement = (spec: Spec, key: string, depth: number): string => {
       `adapter-arte-odyssey codegen: missing formatter for "${element.type}". Add an entry to formatters in code-output.ts.`,
     );
   }
+  usedTypes.add(element.type);
+  visiting.add(key);
   const children = (element.children ?? [])
-    .map((childKey) => renderElement(spec, childKey, depth + 1))
+    .map((childKey) =>
+      renderElement(spec, childKey, depth + 1, visiting, usedTypes),
+    )
     .filter((s) => s !== '');
+  visiting.delete(key);
   return formatter(element, children, depth);
 };
 
 const generate = (spec: Spec): string => {
   if (spec.root === '' || !spec.elements[spec.root]) return '';
-  const used = [...collectUsedComponents(spec)].toSorted();
-  if (used.length === 0) return '';
+  // Collect types during the same depth-first walk that emits the JSX so
+  // cycles get caught here instead of inside json-render's helper, which
+  // does its own walk without cycle protection.
+  const usedTypes = new Set<string>();
+  const body = renderElement(spec, spec.root, 1, new Set<string>(), usedTypes);
+  if (usedTypes.size === 0) return '';
+  const used = [...usedTypes].toSorted();
   const importLine = `import { ${used.join(', ')} } from '${importPath}';`;
-  const body = renderElement(spec, spec.root, 1);
   return [
     importLine,
     '',

--- a/packages/adapter-spec/src/index.ts
+++ b/packages/adapter-spec/src/index.ts
@@ -22,11 +22,22 @@ export type AdapterRegistry<TComponent = unknown> = Record<string, TComponent>;
 /**
  * Hooks an adapter exposes for turning a `json-render` Spec into TSX.
  *
+ * **MVP-only contract.** Today this shape assumes a single TSX string and a
+ * single ES module import path — the React + ArteOdyssey pairing the MVP
+ * targets. That assumption leaks "TSX / React" into adapter-spec, which is
+ * supposed to be framework-agnostic. The next non-React adapter (Vue,
+ * Svelte, Solid) will force this shape to grow into something like
+ * `{ filename, content }[]` keyed by output target. Per ADR-004 we do not
+ * pre-abstract — this comment is the contract that the broader shape is on
+ * the first-release roadmap (see docs/mvp-scope.md "Beyond MVP"), not in
+ * MVP itself.
+ *
  * - `importPath`: where the generated code imports components from (e.g.
  *   `'@k8o/arte-odyssey'`).
- * - `generate(spec)`: returns a single self-contained TSX string. Empty spec
- *   yields `''`. Per-component formatting (e.g. mapping a `label` prop to
- *   children for buttons) lives inside the adapter's implementation.
+ * - `generate(spec)`: returns a self-contained TSX string. Empty spec
+ *   yields `''`. May throw for malformed input (cycle, unknown component);
+ *   interactive callers should catch and degrade rather than letting the
+ *   exception bubble up.
  */
 export type AdapterCodeOutput = {
   importPath: string;


### PR DESCRIPTION
## Summary

Apply the two P1 findings from Codex's deep review of M9:

1. \`AdapterCodeOutput\` in \`adapter-spec\` quietly bakes "TSX + a single ES module import" into a layer that is supposed to be framework-agnostic. The next non-React adapter would need a breaking change.
2. \`apps/web\`'s \`CodePanel\` calls the adapter's \`generate\` synchronously inside \`useMemo\` with no fallback. A streaming intermediate spec that references an unrendered child key, a future Catalog entry without a formatter, or a (theoretical) cycle would throw and take the right pane down with it.

## Changes

- **adapter-spec**: \`AdapterCodeOutput\` grows a clearer docstring stating the contract is MVP-TSX-only and that broadening it is first-release work, not MVP. Documents that \`generate\` may throw and that interactive callers should catch.
- **adapter-arte-odyssey**: \`renderElement\` now tracks both \`visiting\` (cycle detection) and \`usedTypes\` (so we no longer call json-render's \`collectUsedComponents\`, which has no cycle protection and was overflowing the stack on adversarial specs). Added a \`MAX_DEPTH\` guard. Two regression tests cover the unknown-component and cycle paths.
- **apps/web/CodePanel**: state machine (\`empty\` / \`ok\` / \`error\`) wraps the \`generate\` call so a malformed intermediate spec surfaces as "Code generation paused: <message>" while the live preview and chat keep running.

## P2 items deliberately deferred to M10 smoke test

- Shiki re-highlight cost on every spec patch (Codex flagged as overhead). Current spec sizes (Card + Button) make this a non-issue; revisit only if M10 surfaces actual lag.
- TypeScript/SWC parse coverage in tests (Codex flagged that the string-include assertions are weak). M10 already plans to copy generated TSX into a real React project as the smoke test — adding a parse test would be redundant with that.

## Test plan

- [x] \`pnpm typecheck\` / \`pnpm check\` / \`pnpm test\` (9/9, including the new cycle and unknown-component cases) pass
- [ ] Visual: with the dev server running, post a chat message that the LLM can't render cleanly — the right pane shows the "Code generation paused" message instead of going blank