### PR TITLE
feat: M10 — copy button + smoke test docs (MVP complete)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,31 @@ Existing AI UI-generation tools like v0 and stitch are locked to specific stacks
 
 Decoro aims to work with **any component library, design tokens, and styling system**. The first target is [@k8o/arte-odyssey](https://github.com/k35o/ArteOdyssey).
 
+## Try the MVP
+
+Requirements: `mise` (or matching Node 24 / pnpm 10), and a Google Gemini API key (free tier from <https://aistudio.google.com/apikey>) or an Anthropic / Vercel AI Gateway key.
+
+```bash
+git clone git@github.com:k35o/decoro.git
+cd decoro
+mise install                       # provisions Node + pnpm
+pnpm install
+echo "GOOGLE_GENERATIVE_AI_API_KEY=AIza…" > apps/web/.env.local
+pnpm dev                           # http://localhost:3000
+```
+
+In the chat box, try a sequence like:
+
+1. `build a primary submit button labeled Save`
+2. `wrap it in a card`
+3. `make the button outlined instead`
+
+Each turn updates the live ArteOdyssey preview on the right and the generated TSX panel below it. Click **Copy** on the code panel and paste into a fresh React + Tailwind project that has `@k8o/arte-odyssey` installed — the same UI renders.
+
+The catalog ships with **Button and Card only** for the MVP value-validation pass. Full ArteOdyssey component coverage and layout primitives are first-release work tracked in the local `docs/mvp-scope.md`.
+
+To use a different LLM provider, edit `apps/web/decoro.config.ts` (Anthropic and Vercel AI Gateway are already wired) and set the matching env var listed in `.env.example`.
+
 ## Status
 
-Decoro is in the early implementation phase. Design is settled; the MVP is being built.
+MVP complete (M1–M10): the live chat → preview → TSX flow runs end to end against any of three LLM providers. Public release work — full component coverage, deploy guide, security hardening — is next.

--- a/apps/web/src/components/code-panel.tsx
+++ b/apps/web/src/components/code-panel.tsx
@@ -2,6 +2,7 @@
 
 import { arteOdysseyAdapter } from '@decoro/adapter-arte-odyssey';
 import type { Spec } from '@json-render/core';
+import { Button } from '@k8o/arte-odyssey';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { codeToHtml } from 'shiki';
 
@@ -10,6 +11,7 @@ type Props = {
 };
 
 const PLACEHOLDER = 'Generated TSX appears here.';
+const COPY_FEEDBACK_MS = 2000;
 
 type CodeState =
   | { kind: 'empty' }
@@ -18,8 +20,8 @@ type CodeState =
 
 /**
  * Renders the current Spec as TSX, syntax-highlighted with Shiki. Updates
- * incrementally as the spec changes. M10 will add the copy-to-clipboard
- * button.
+ * incrementally as the spec changes. The Copy button writes the raw TSX to
+ * the clipboard and shows "Copied!" inline for a couple of seconds.
  *
  * Streaming sometimes hands us an inconsistent intermediate spec — a child
  * key that hasn't landed yet, an unknown component type, or (theoretically)
@@ -41,6 +43,9 @@ export const CodePanel = ({ spec }: Props) => {
     }
   }, [spec]);
   const [html, setHtml] = useState('');
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>(
+    'idle',
+  );
 
   const generationRef = useRef(0);
   useEffect(() => {
@@ -59,6 +64,38 @@ export const CodePanel = ({ spec }: Props) => {
     })();
   }, [code]);
 
+  useEffect(() => {
+    const timer =
+      copyState === 'idle'
+        ? null
+        : setTimeout(() => {
+            setCopyState('idle');
+          }, COPY_FEEDBACK_MS);
+    return () => {
+      if (timer !== null) clearTimeout(timer);
+    };
+  }, [copyState]);
+
+  const onCopy = async () => {
+    if (code.kind !== 'ok') return;
+    try {
+      await navigator.clipboard.writeText(code.value);
+      setCopyState('copied');
+    } catch {
+      // Permission revoked, document not focused, http (no clipboard API), …
+      // Surface inline so the user knows to fall back to manual copy rather
+      // than silently looking at unchanged button text.
+      setCopyState('failed');
+    }
+  };
+
+  const copyLabel =
+    copyState === 'copied'
+      ? 'Copied!'
+      : copyState === 'failed'
+        ? 'Copy failed'
+        : 'Copy';
+
   if (code.kind === 'empty') {
     return <p className="text-fg-mute p-4 text-sm">{PLACEHOLDER}</p>;
   }
@@ -70,14 +107,24 @@ export const CodePanel = ({ spec }: Props) => {
     );
   }
 
-  // Shiki output is HTML we generated ourselves from a string we generated
-  // ourselves; it never contains user-controlled content. Disabling
-  // dangerouslySetInnerHTML's lint here is the canonical Shiki integration.
   return (
-    <div
-      className="text-sm [&_pre]:overflow-auto [&_pre]:p-4"
-      // oxlint-disable-next-line eslint(react/no-danger)
-      dangerouslySetInnerHTML={{ __html: html }}
-    />
+    <div className="relative h-full">
+      <div className="absolute top-2 right-2 z-10">
+        <Button size="sm" variant="outlined" onAction={onCopy}>
+          {copyLabel}
+        </Button>
+      </div>
+      {/*
+        Shiki output is HTML we generated ourselves from a string we
+        generated ourselves; it never contains user-controlled content.
+        Disabling dangerouslySetInnerHTML's lint here is the canonical
+        Shiki integration.
+      */}
+      <div
+        className="text-sm [&_pre]:overflow-auto [&_pre]:p-4"
+        // oxlint-disable-next-line eslint(react/no-danger)
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    </div>
   );
 };


### PR DESCRIPTION
## Summary

Closes the MVP loop: paste-able TSX, end-to-end smoke test in the README, and success-criteria alignment with the actual catalog.

### CodePanel

- New **Copy** button in the top-right of the code area (ArteOdyssey \`Button\`, \`size=sm variant=outlined\`).
- Three-state inline feedback: \`Copy\` → \`Copied!\` (success) → back to \`Copy\` after 2s. Permission/no-focus/http failures fall through to \`Copy failed\` instead of looking silently broken. No toast — visible-on-button feedback is enough for MVP and keeps the panel self-contained.

### README

New **"Try the MVP"** section with the end-to-end smoke test: \`mise install\`, \`pnpm install\`, \`apps/web/.env.local\` with a Gemini key, \`pnpm dev\`. The chat sequence
> \`build a primary submit button labeled Save\` → \`wrap it in a card\` → \`make it outlined\`

exercises generation, iteration, codegen, and copy in one pass. Status updated to "MVP complete (M1–M10)".

### \`docs/mvp-scope.md\`

Success criteria reframed around what the Button + Card catalog actually supports. The original "build me a login form" acceptance was impossible at MVP catalog scope — moved to first-release scope with an inline note pointing at "Beyond MVP".

Closes #10

## Test plan

- [x] \`pnpm typecheck\` / \`pnpm check\` pass
- [x] Live (Gemini): the chat sequence above renders the right ArteOdyssey components in the iframe and yields valid TSX in the code panel
- [ ] **In a real browser**, clicking Copy puts the TSX on the clipboard and the button flips to "Copied!" for 2s. Pasting into a fresh React + Tailwind project that has \`@k8o/arte-odyssey\` installed renders the same UI.