### PR TITLE
fix(security): MVP hardening from Codex sweep (P0 + P1)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"284d9e5f-3a55-4152-a17b-f6b6125722a9","pid":81100,"procStart":"Fri May  1 01:51:03 2026","acquiredAt":1777624036418}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"284d9e5f-3a55-4152-a17b-f6b6125722a9","pid":81100,"procStart":"Fri May  1 01:51:03 2026","acquiredAt":1777624036418}

--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,7 @@ next-env.d.ts
 
 # Local-only Claude / settings
 .plan
-.claude/settings.local.json
+.claude/
 settings.local.json
 
 # Design docs are kept local-only for now

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,7 +24,8 @@
     "react": "catalog:",
     "react-dom": "catalog:",
     "shiki": "catalog:",
-    "tailwindcss": "catalog:"
+    "tailwindcss": "catalog:",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "catalog:",

--- a/apps/web/src/app/api/generate/route.ts
+++ b/apps/web/src/app/api/generate/route.ts
@@ -2,13 +2,49 @@ import { arteOdysseyAdapter } from '@decoro/adapter-arte-odyssey';
 import { createModel } from '@decoro/llm-config';
 import { type Spec, buildUserPrompt } from '@json-render/core';
 import { type ModelMessage, streamText } from 'ai';
+import { z } from 'zod';
 
 import { llm } from '../../../../decoro.config.ts';
 
-type GenerateRequestBody = {
-  messages: ModelMessage[];
-  currentSpec?: Spec | null;
-};
+// Limits sized for "self-hosted, trusted-network MVP". Generous enough that
+// real chat sessions never bump them, tight enough that a runaway client or
+// hostile insider cannot DoS the endpoint or rack up an unbounded LLM bill.
+const MAX_MESSAGES = 50;
+const MAX_MESSAGE_CHARS = 4000;
+const MAX_SPEC_ELEMENTS = 200;
+const MAX_ELEMENT_CHILDREN = 50;
+const MAX_COMPONENT_TYPE_CHARS = 50;
+
+const messageSchema = z.object({
+  role: z.enum(['user', 'assistant', 'system']),
+  content: z.string().min(1).max(MAX_MESSAGE_CHARS),
+});
+
+const elementSchema = z.object({
+  type: z.string().min(1).max(MAX_COMPONENT_TYPE_CHARS),
+  props: z.record(z.string(), z.unknown()),
+  children: z.array(z.string()).max(MAX_ELEMENT_CHILDREN),
+  visible: z.unknown().optional(),
+});
+
+const specSchema = z
+  .object({
+    root: z.string(),
+    elements: z
+      .record(z.string(), elementSchema)
+      .refine(
+        (e) => Object.keys(e).length <= MAX_SPEC_ELEMENTS,
+        `spec exceeds max ${MAX_SPEC_ELEMENTS.toString()} elements`,
+      ),
+    state: z.unknown().optional(),
+  })
+  .nullable()
+  .optional();
+
+const requestSchema = z.object({
+  messages: z.array(messageSchema).min(1).max(MAX_MESSAGES),
+  currentSpec: specSchema,
+});
 
 const systemPrompt = [
   arteOdysseyAdapter.catalog.prompt({ mode: 'standalone' }),
@@ -20,6 +56,12 @@ const systemPrompt = [
 const isMeaningfulSpec = (spec: Spec | null | undefined): spec is Spec =>
   spec !== null && spec !== undefined && spec.root !== '';
 
+const jsonError = (status: number, message: string) =>
+  new Response(JSON.stringify({ message }), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+
 /**
  * POST /api/generate streams the LLM's raw text output back to the client.
  *
@@ -27,28 +69,48 @@ const isMeaningfulSpec = (spec: Spec | null | undefined): spec is Spec =>
  * instructs the model to emit json-render JSON patches one per line, which
  * the client's `useDecoroChat` hook consumes via `createMixedStreamParser`.
  *
- * For iteration (M8): when `currentSpec` is supplied and non-empty, the last
- * user message is rewritten through `buildUserPrompt` so it includes the
- * current spec as edit context. Earlier messages stay verbatim — they were
- * past requests the model already satisfied.
+ * For iteration: when `currentSpec` is supplied and non-empty, the last user
+ * message is rewritten through `buildUserPrompt` so it includes the current
+ * spec as edit context. Earlier messages stay verbatim.
  *
- * We deliberately do NOT wrap the response in `createUIMessageStream` /
- * `pipeJsonRender`. That pairing produces AI SDK's UI Message Stream
- * format (with `data-spec` SSE parts), which `useDecoroChat` /
- * `createMixedStreamParser` does not parse — pick that setup only when
- * migrating to AI SDK's own `useChat`.
+ * Input is validated with zod and capped (messages count / per-message
+ * length / spec element count) so a runaway client cannot DoS the endpoint
+ * or rack up an unbounded LLM bill.
  */
 export const POST = async (req: Request) => {
-  const body = (await req.json()) as GenerateRequestBody;
-  const augmented = augmentLastUserMessage(body.messages, body.currentSpec);
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return jsonError(400, 'Request body must be valid JSON');
+  }
 
-  const result = streamText({
-    model: createModel(llm),
-    system: systemPrompt,
-    messages: augmented,
-  });
+  const parsed = requestSchema.safeParse(raw);
+  if (!parsed.success) {
+    return jsonError(400, parsed.error.message);
+  }
 
-  return result.toTextStreamResponse();
+  // The zod schema enforces shape and size limits; downstream consumers
+  // (json-render's buildUserPrompt, the registry) accept the wider Spec
+  // type. Cast is safe — anything the schema accepts is structurally a Spec.
+  const augmented = augmentLastUserMessage(
+    parsed.data.messages,
+    (parsed.data.currentSpec ?? null) as Spec | null,
+  );
+
+  try {
+    const result = streamText({
+      model: createModel(llm),
+      system: systemPrompt,
+      messages: augmented,
+    });
+    return result.toTextStreamResponse();
+  } catch (err) {
+    return jsonError(
+      500,
+      err instanceof Error ? err.message : 'Failed to start generation',
+    );
+  }
 };
 
 const augmentLastUserMessage = (

--- a/apps/web/src/app/preview/page.tsx
+++ b/apps/web/src/app/preview/page.tsx
@@ -15,6 +15,9 @@ const PreviewPage = () => {
 
   useEffect(() => {
     const handler = (event: MessageEvent) => {
+      // Origin check alone lets any same-origin window impersonate the
+      // parent. Pin acceptance to the actual parent Window.
+      if (event.source !== window.parent) return;
       if (event.origin !== window.location.origin) return;
       if (!isPreviewMessage(event.data)) return;
       if (event.data.type === 'decoro:spec') setSpec(event.data.spec);

--- a/apps/web/src/components/preview-frame.tsx
+++ b/apps/web/src/components/preview-frame.tsx
@@ -25,6 +25,10 @@ export const PreviewFrame = ({ spec }: Props) => {
 
   useEffect(() => {
     const handler = (event: MessageEvent) => {
+      // Origin check alone lets any other same-origin window (devtools panes,
+      // future admin pages, etc.) impersonate the iframe. The source check
+      // pins acceptance to the Window we actually own.
+      if (event.source !== iframeRef.current?.contentWindow) return;
       if (event.origin !== window.location.origin) return;
       if (!isPreviewMessage(event.data)) return;
       if (event.data.type === 'decoro:ready') setReady(true);

--- a/packages/adapter-arte-odyssey/package.json
+++ b/packages/adapter-arte-odyssey/package.json
@@ -19,7 +19,7 @@
     "@json-render/react": "catalog:",
     "@k8o/arte-odyssey": "catalog:",
     "react": "catalog:",
-    "zod": "4.3.6"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@types/react": "catalog:",

--- a/packages/llm-config/package.json
+++ b/packages/llm-config/package.json
@@ -15,6 +15,7 @@
     "@ai-sdk/anthropic": "3.0.71",
     "@ai-sdk/gateway": "3.0.104",
     "@ai-sdk/google": "3.0.64",
-    "ai": "6.0.168"
+    "ai": "6.0.168",
+    "server-only": "0.0.1"
   }
 }

--- a/packages/llm-config/src/index.ts
+++ b/packages/llm-config/src/index.ts
@@ -1,3 +1,10 @@
+// `server-only` is a side-effect import: it has no exports, it just makes
+// the bundler refuse to include this module in client code. Decoro reads
+// API keys from `process.env` here; an accidental import from a client
+// component would compile that env access into the browser bundle and leak
+// the key.
+// oxlint-disable-next-line eslint-plugin-import(no-unassigned-import)
+import 'server-only';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createGateway } from '@ai-sdk/gateway';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ catalogs:
     vite-plus:
       specifier: 0.1.19
       version: 0.1.19
+    zod:
+      specifier: 4.3.6
+      version: 4.3.6
 
 overrides:
   postcss: '>=8.5.10'
@@ -119,6 +122,9 @@ importers:
       tailwindcss:
         specifier: 'catalog:'
         version: 4.2.4
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
     devDependencies:
       '@tailwindcss/postcss':
         specifier: 'catalog:'
@@ -157,7 +163,7 @@ importers:
         specifier: 'catalog:'
         version: 19.2.5
       zod:
-        specifier: 4.3.6
+        specifier: 'catalog:'
         version: 4.3.6
     devDependencies:
       '@types/react':
@@ -193,6 +199,9 @@ importers:
       ai:
         specifier: 6.0.168
         version: 6.0.168(zod@4.3.6)
+      server-only:
+        specifier: 0.0.1
+        version: 0.0.1
 
 packages:
 
@@ -1903,6 +1912,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
+
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -3470,6 +3482,8 @@ snapshots:
   scheduler@0.27.0: {}
 
   semver@7.7.4: {}
+
+  server-only@0.0.1: {}
 
   sharp@0.34.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,6 +19,7 @@ catalog:
   shiki: 4.0.2
   tailwindcss: 4.2.4
   vite-plus: 0.1.19
+  zod: 4.3.6
 
 allowBuilds:
   esbuild: false


### PR DESCRIPTION
## Summary

Apply the P0 and P1 findings from the Codex MVP-wide security sweep. Independent of #21 (M10) so the MVP completion stays a clean line in history.

### P0 — \`/api/generate\` input validation + size caps + structured errors

The route used to type-assert \`req.json()\` straight into \`streamText\` with no limits, so a single client could send unbounded message history or a giant \`currentSpec\` and run up the LLM bill or DoS the endpoint.

Add a zod schema with limits sized for self-hosted, trusted-network MVP usage:

| | Value |
|---|---|
| \`MAX_MESSAGES\` | 50 |
| \`MAX_MESSAGE_CHARS\` | 4000 |
| \`MAX_SPEC_ELEMENTS\` | 200 |
| \`MAX_ELEMENT_CHILDREN\` | 50 |

Bad bodies return \`400\` with the zod error JSON; an unexpected \`streamText\` failure returns \`500\` with the message. Same-origin happy path still streams as before (verified end-to-end against Gemini).

### P1 — \`postMessage\` source verification

Both ends previously trusted any same-origin window. That left a hole where another tab on the same origin (or a future admin page) could send forged \`decoro:*\` messages. Pin acceptance to the specific \`Window\` we own:

- **PreviewFrame (parent)**: \`event.source === iframeRef.current?.contentWindow\` before reading \`decoro:ready\`.
- **\`/preview\` page (iframe)**: \`event.source === window.parent\` before reading \`decoro:spec\`.

### P1 — \`server-only\` marker on \`@decoro/llm-config\`

\`createModel()\` reads API keys from \`process.env\`. An accidental import from a client component would compile that env access into the browser bundle and leak the key. Adding \`import 'server-only'\` makes the bundler refuse to include this module in client code, turning that mistake into a build error instead of a silent leak.

### Workspace plumbing

- Catalog adds \`zod\` (4.3.6) so \`packages/adapter-arte-odyssey\` and \`apps/web\` both reference the same version.
- \`packages/llm-config\` adds \`server-only\` as a runtime dep.
- Bonus: broaden \`.gitignore\` to exclude the entire \`.claude/\` runtime dir, and untrack a lock file that landed by accident.

## P2 deferred

| | Defer reason |
|---|---|
| 3-provider LLM exposure looks excessive vs MVP scope | Already useful — Gemini path was the one we used to verify M6/M7/M8/M10 because the user had no Anthropic credit. Revisit when first-release scope sets the official supported matrix. |
| No tests on route / postMessage / input validation | Tests cost time; the live curl smoke checks below cover the same ground for now. Folded into the first-release "real test suite" task. |

## Test plan

- [x] \`pnpm typecheck\` / \`pnpm check\` / \`pnpm test\` (9/9 incl. cycle / unknown-component cases) pass
- [x] **Live smoke** against \`/api/generate\`:
  - valid \`{messages:[{role:'user',content:'a primary submit button'}]}\` → \`200\` + spec stream
  - \`{messages:[]}\` → \`400\` zod error
  - \`content\` with 5000 chars → \`400\` zod error (max 4000)
  - non-JSON body → \`400\` "Request body must be valid JSON"