### PR TITLE
feat(adapter): ADR-012 layout HTML elements with className allowlist

### DIFF
--- a/packages/adapter-arte-odyssey/src/adapter.test.tsx
+++ b/packages/adapter-arte-odyssey/src/adapter.test.tsx
@@ -1,6 +1,7 @@
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 
+import { isAllowedClassName } from './class-name-allowlist.ts';
 import { arteOdysseyAdapter } from './index.ts';
 
 const fakeRenderProps = <P,>(element: { type: string; props: P }) => ({
@@ -141,5 +142,89 @@ describe('adapter-arte-odyssey', () => {
       ),
     );
     expect(html).toContain('Submit');
+  });
+
+  describe('layout HTML elements (ADR-012)', () => {
+    it('exposes div / section / header / main in the registry', () => {
+      expect(arteOdysseyAdapter.registry).toHaveProperty('div');
+      expect(arteOdysseyAdapter.registry).toHaveProperty('section');
+      expect(arteOdysseyAdapter.registry).toHaveProperty('header');
+      expect(arteOdysseyAdapter.registry).toHaveProperty('main');
+    });
+
+    it('renders div via the registry with a passed className', () => {
+      const DivRenderer = arteOdysseyAdapter.registry['div']!;
+      const html = renderToStaticMarkup(
+        createElement(
+          DivRenderer,
+          fakeRenderProps({
+            type: 'div',
+            props: { className: 'flex flex-col gap-4' },
+          }),
+          'pane',
+        ),
+      );
+      expect(html).toBe('<div class="flex flex-col gap-4">pane</div>');
+    });
+
+    it('emits HTML elements verbatim in generated TSX (no import line)', () => {
+      const tsx = arteOdysseyAdapter.codeOutput.generate({
+        root: 'shell',
+        elements: {
+          shell: {
+            type: 'div',
+            props: { className: 'flex flex-col gap-4 p-6' },
+            children: ['btn'],
+          },
+          btn: {
+            type: 'Button',
+            props: {
+              label: 'Save',
+              type: null,
+              size: null,
+              color: null,
+              variant: null,
+              fullWidth: null,
+              disabled: null,
+            },
+            children: [],
+          },
+        },
+      });
+      // Only ArteOdyssey components (Button) belong in the import line; div
+      // is native HTML and stays out of it.
+      expect(tsx).toContain("import { Button } from '@k8o/arte-odyssey';");
+      expect(tsx).not.toContain(', div');
+      expect(tsx).not.toContain('div }');
+      expect(tsx).toContain('<div className="flex flex-col gap-4 p-6">');
+      expect(tsx).toContain('</div>');
+    });
+
+    it('emits a self-closing tag when className is null and there are no children', () => {
+      const tsx = arteOdysseyAdapter.codeOutput.generate({
+        root: 'spacer',
+        elements: {
+          spacer: { type: 'section', props: { className: null }, children: [] },
+        },
+      });
+      expect(tsx).toContain('<section />');
+    });
+  });
+
+  describe('className allowlist (ADR-012)', () => {
+    it('accepts curated layout utilities', () => {
+      expect(isAllowedClassName('flex')).toBe(true);
+      expect(isAllowedClassName('flex flex-col gap-4 p-6')).toBe(true);
+      expect(isAllowedClassName('w-full bg-bg-base text-fg-base')).toBe(true);
+      expect(isAllowedClassName('  flex   gap-2  ')).toBe(true);
+      expect(isAllowedClassName('')).toBe(true);
+    });
+
+    it('rejects raw palette / arbitrary / off-token utilities', () => {
+      expect(isAllowedClassName('bg-red-500')).toBe(false);
+      expect(isAllowedClassName('text-9xl')).toBe(false);
+      expect(isAllowedClassName('gap-[37px]')).toBe(false);
+      expect(isAllowedClassName('flex bg-red-500')).toBe(false);
+    });
   });
 });

--- a/packages/adapter-arte-odyssey/src/catalog.ts
+++ b/packages/adapter-arte-odyssey/src/catalog.ts
@@ -2,6 +2,8 @@ import { defineCatalog } from '@json-render/core';
 import { schema } from '@json-render/react/schema';
 import { z } from 'zod';
 
+import { isAllowedClassName } from './class-name-allowlist.ts';
+
 const buttonProps = z.object({
   label: z.string().describe('Visible button text.'),
   type: z.enum(['button', 'submit']).nullable(),
@@ -17,6 +19,30 @@ const cardProps = z.object({
   appearance: z.enum(['shadow', 'bordered']).nullable(),
 });
 
+/**
+ * Layout HTML element shape (per ADR-012). The only prop is `className`,
+ * constrained at the Zod layer to a curated allowlist so the LLM cannot
+ * break out of the design system.
+ */
+const layoutElementProps = z.object({
+  className: z
+    .string()
+    .nullable()
+    .refine((v) => v === null || isAllowedClassName(v), {
+      message:
+        'className must use only design-system-aligned utilities (display, flex/grid, gap-*, p-*, m-*, w-*, h-*, ArteOdyssey token-bound colors, rounded-*, etc.). Free-form Tailwind is rejected.',
+    }),
+});
+
+const layoutDescription = (tag: string, semantics: string) =>
+  [
+    `Native <${tag}> element for layout / composition. ${semantics}`,
+    '',
+    'Set `className` to combine ArteOdyssey-token-aligned Tailwind utilities for layout: display (`flex`, `grid`), direction (`flex-col`, `flex-row`), alignment (`items-center`, `justify-between`), gap (`gap-4`), padding (`p-6`, `px-4`), sizing (`w-full`, `max-w-md`), token colors (`bg-bg-base`, `border-border-mute`), borders (`border`, `rounded-xl`).',
+    '',
+    'Free-form Tailwind (e.g. `bg-red-500`, `text-9xl`, `gap-[37px]`) is rejected — use only the curated allowlist.',
+  ].join('\n');
+
 export const catalog = defineCatalog(schema, {
   components: {
     Button: {
@@ -31,9 +57,42 @@ export const catalog = defineCatalog(schema, {
       description:
         'Container for grouping content. Use `appearance: "bordered"` when stacking multiple cards on the same surface, otherwise leave the default shadow.',
     },
+    div: {
+      props: layoutElementProps,
+      slots: ['default'],
+      description: layoutDescription(
+        'div',
+        'Generic block container. Default for layout grouping when no semantic element fits.',
+      ),
+    },
+    section: {
+      props: layoutElementProps,
+      slots: ['default'],
+      description: layoutDescription(
+        'section',
+        'Use for thematic groupings of content (a hero section, a card grid, etc.).',
+      ),
+    },
+    header: {
+      props: layoutElementProps,
+      slots: ['default'],
+      description: layoutDescription(
+        'header',
+        'Use for the top of a page or a thematic block (titles, intro content, primary navigation row).',
+      ),
+    },
+    main: {
+      props: layoutElementProps,
+      slots: ['default'],
+      description: layoutDescription(
+        'main',
+        'The dominant content area of a page. There should be at most one per page.',
+      ),
+    },
   },
   actions: {},
 });
 
 export type ButtonProps = z.infer<typeof buttonProps>;
 export type CardProps = z.infer<typeof cardProps>;
+export type LayoutElementProps = z.infer<typeof layoutElementProps>;

--- a/packages/adapter-arte-odyssey/src/class-name-allowlist.ts
+++ b/packages/adapter-arte-odyssey/src/class-name-allowlist.ts
@@ -1,0 +1,186 @@
+/**
+ * Curated subset of Tailwind utilities the LLM is allowed to put on a layout
+ * HTML element (per ADR-012). Anything outside this set fails the Zod
+ * refinement on `className`, so the model physically cannot emit
+ * `bg-red-500`, `text-9xl`, `gap-[37px]`, or other off-design-system values.
+ *
+ * The set is intentionally narrow at first — composition (display, flex
+ * direction, gap, alignment, sizing) plus token-bound colors. Grow it as
+ * real demos surface needs; do **not** open it to arbitrary palette / size
+ * utilities.
+ *
+ * Kept as a module-level Set so the Zod refine is O(tokens) per validation.
+ */
+const ALLOWED_CLASSES = new Set<string>([
+  // Display
+  'flex',
+  'inline-flex',
+  'grid',
+  'block',
+  'inline-block',
+  'hidden',
+  'relative',
+  'absolute',
+  'sticky',
+
+  // Flex direction / wrap
+  'flex-col',
+  'flex-row',
+  'flex-wrap',
+  'flex-nowrap',
+
+  // Alignment
+  'items-start',
+  'items-center',
+  'items-end',
+  'items-stretch',
+  'items-baseline',
+  'self-start',
+  'self-center',
+  'self-end',
+  'self-stretch',
+
+  // Justify
+  'justify-start',
+  'justify-center',
+  'justify-end',
+  'justify-between',
+  'justify-around',
+  'justify-evenly',
+
+  // Gap
+  'gap-0',
+  'gap-1',
+  'gap-2',
+  'gap-3',
+  'gap-4',
+  'gap-5',
+  'gap-6',
+  'gap-8',
+  'gap-10',
+  'gap-12',
+
+  // Padding (common scale)
+  'p-0',
+  'p-1',
+  'p-2',
+  'p-3',
+  'p-4',
+  'p-5',
+  'p-6',
+  'p-8',
+  'p-10',
+  'p-12',
+  'px-1',
+  'px-2',
+  'px-3',
+  'px-4',
+  'px-5',
+  'px-6',
+  'px-8',
+  'py-1',
+  'py-2',
+  'py-3',
+  'py-4',
+  'py-5',
+  'py-6',
+  'py-8',
+  'pt-2',
+  'pt-4',
+  'pt-6',
+  'pb-2',
+  'pb-4',
+  'pb-6',
+  'pl-2',
+  'pl-4',
+  'pr-2',
+  'pr-4',
+
+  // Margin (common scale)
+  'm-0',
+  'm-auto',
+  'm-1',
+  'm-2',
+  'm-3',
+  'm-4',
+  'm-6',
+  'm-8',
+  'mx-auto',
+  'my-2',
+  'my-4',
+  'my-6',
+  'mt-2',
+  'mt-4',
+  'mt-6',
+  'mb-2',
+  'mb-4',
+  'mb-6',
+
+  // Sizing
+  'w-full',
+  'w-fit',
+  'w-auto',
+  'w-1/2',
+  'w-1/3',
+  'w-2/3',
+  'w-1/4',
+  'w-3/4',
+  'h-full',
+  'h-fit',
+  'h-auto',
+  'h-dvh',
+  'min-h-dvh',
+  'min-h-0',
+  'max-w-sm',
+  'max-w-md',
+  'max-w-lg',
+  'max-w-xl',
+  'max-w-2xl',
+
+  // ArteOdyssey token-bound colors only (no raw palette)
+  'bg-bg-base',
+  'bg-bg-raised',
+  'bg-bg-surface',
+  'bg-bg-mute',
+  'bg-bg-subtle',
+  'text-fg-base',
+  'text-fg-mute',
+  'border-border-mute',
+  'border-border-emphasize',
+  'border-border-inverse',
+
+  // Borders
+  'border',
+  'border-t',
+  'border-b',
+  'border-l',
+  'border-r',
+  'border-2',
+  'rounded-sm',
+  'rounded-md',
+  'rounded-lg',
+  'rounded-xl',
+  'rounded-2xl',
+  'rounded-full',
+
+  // Overflow
+  'overflow-hidden',
+  'overflow-auto',
+  'overflow-y-auto',
+  'overflow-x-auto',
+]);
+
+/**
+ * True when every space-separated token in `value` is in the allowlist.
+ * Empty / whitespace-only string is allowed.
+ */
+export const isAllowedClassName = (value: string): boolean => {
+  const tokens = value.split(/\s+/).filter(Boolean);
+  return tokens.every((token) => ALLOWED_CLASSES.has(token));
+};
+
+/**
+ * Read-only view of the allowlist, exported for tests and for the LLM-facing
+ * description string in the catalog.
+ */
+export const allowedClasses = (): readonly string[] => [...ALLOWED_CLASSES];

--- a/packages/adapter-arte-odyssey/src/code-output.ts
+++ b/packages/adapter-arte-odyssey/src/code-output.ts
@@ -19,6 +19,37 @@ type Formatter = (
 ) => string;
 
 /**
+ * Native HTML element types (per ADR-012). Anything in this set is emitted
+ * verbatim as a lowercase tag and never appears in the import line.
+ */
+const HTML_TAGS = new Set(['div', 'section', 'header', 'main']);
+
+/**
+ * Factory for ADR-012 layout HTML element formatters. The Zod refinement on
+ * `className` runs upstream, so by the time we land here the value is
+ * guaranteed to be either `null` or a safe, allowlist-checked utility string
+ * (no quotes, no JSX-significant characters); we can interpolate it into a
+ * `className="…"` attribute without further escaping.
+ */
+const layoutElementFormatter =
+  (tag: string): Formatter =>
+  (element, renderedChildren, depth) => {
+    const { className } = element.props as { className?: unknown };
+    const classNameAttr =
+      typeof className === 'string' && className.length > 0
+        ? ` className="${className}"`
+        : '';
+    if (renderedChildren.length === 0) {
+      return `${pad(depth)}<${tag}${classNameAttr} />`;
+    }
+    return [
+      `${pad(depth)}<${tag}${classNameAttr}>`,
+      ...renderedChildren,
+      `${pad(depth)}</${tag}>`,
+    ].join('\n');
+  };
+
+/**
  * Per-component formatters. Each one knows the gap between the AI-facing
  * Catalog shape (e.g. Button taking `label` as a prop) and the real
  * ArteOdyssey component shape (Button taking children).
@@ -59,6 +90,10 @@ const formatters: Record<string, Formatter> = {
       `${pad(depth)}</Card>`,
     ].join('\n');
   },
+  div: layoutElementFormatter('div'),
+  section: layoutElementFormatter('section'),
+  header: layoutElementFormatter('header'),
+  main: layoutElementFormatter('main'),
 };
 
 const MAX_DEPTH = 64;
@@ -107,16 +142,20 @@ const generate = (spec: Spec): string => {
   const usedTypes = new Set<string>();
   const body = renderElement(spec, spec.root, 1, new Set<string>(), usedTypes);
   if (usedTypes.size === 0) return '';
-  const used = [...usedTypes].toSorted();
-  const importLine = `import { ${used.join(', ')} } from '${importPath}';`;
-  return [
-    importLine,
-    '',
-    'export const GeneratedComponent = () => (',
-    body,
-    ');',
-    '',
-  ].join('\n');
+  // Native HTML tags (ADR-012) need no import; only ArteOdyssey components
+  // appear in the import line.
+  const componentImports = [...usedTypes]
+    .filter((t) => !HTML_TAGS.has(t))
+    .toSorted();
+  const lines: string[] = [];
+  if (componentImports.length > 0) {
+    lines.push(
+      `import { ${componentImports.join(', ')} } from '${importPath}';`,
+      '',
+    );
+  }
+  lines.push('export const GeneratedComponent = () => (', body, ');', '');
+  return lines.join('\n');
 };
 
 export const codeOutput: AdapterCodeOutput = {

--- a/packages/adapter-arte-odyssey/src/registry.tsx
+++ b/packages/adapter-arte-odyssey/src/registry.tsx
@@ -3,8 +3,9 @@ import type {
   ComponentRenderProps,
 } from '@json-render/react';
 import { Button, Card } from '@k8o/arte-odyssey';
+import { createElement } from 'react';
 
-import type { ButtonProps, CardProps } from './catalog.ts';
+import type { ButtonProps, CardProps, LayoutElementProps } from './catalog.ts';
 
 const ButtonRenderer = ({ element }: ComponentRenderProps<ButtonProps>) => {
   const { label, type, size, color, variant, fullWidth, disabled } =
@@ -35,7 +36,31 @@ const CardRenderer = ({
   );
 };
 
+/**
+ * Renderer factory for layout HTML elements (per ADR-012). The Catalog Zod
+ * refinement has already validated `className` against the allowlist, so the
+ * renderer just forwards it. `displayName` is set so React devtools shows
+ * `divRenderer` etc. instead of an anonymous component.
+ */
+const layoutElementRenderer = (tag: string) => {
+  const renderer = ({
+    element,
+    children,
+  }: ComponentRenderProps<LayoutElementProps>) =>
+    createElement(
+      tag,
+      { className: element.props.className ?? undefined },
+      children,
+    );
+  renderer.displayName = `${tag}Renderer`;
+  return renderer;
+};
+
 export const registry: ComponentRegistry = {
   Button: ButtonRenderer,
   Card: CardRenderer,
+  div: layoutElementRenderer('div'),
+  section: layoutElementRenderer('section'),
+  header: layoutElementRenderer('header'),
+  main: layoutElementRenderer('main'),
 };


### PR DESCRIPTION
## Summary

The MVP catalog had Button + Card only and no HTML, so the LLM worked around the lack of layout by nesting Cards. This PR lets the LLM compose UI properly using native HTML (\`<div>\`, \`<section>\`, \`<header>\`, \`<main>\`) plus the existing components, with safety enforced via a Zod-refined \`className\` allowlist.

## Changes

### Catalog (\`catalog.ts\`)

- Adds \`div\` / \`section\` / \`header\` / \`main\` entries. Each has a single \`className\` prop, Zod-refined against a curated token-aligned allowlist (no free-form Tailwind, ever).
- Each description tells the LLM exactly which utility families are usable and explicitly notes that off-allowlist classes are rejected.

### \`class-name-allowlist.ts\` (new)

Curated initial vocabulary:

| Family | Examples |
|---|---|
| Display | \`flex\` / \`grid\` / \`hidden\` / \`relative\` / \`absolute\` / \`sticky\` |
| Direction / wrap | \`flex-col\` / \`flex-row\` / \`flex-wrap\` |
| Items / justify | \`items-center\` / \`justify-between\` / \`self-start\` |
| Gap | \`gap-{0,1,…,12}\` |
| Padding / margin | \`p-{0,…,12}\`, \`px-{1,…,8}\`, \`py-…\`, \`m-…\`, \`mt-…\` (standard scale only) |
| Sizing | \`w-full\` / \`w-fit\` / \`w-1/2\` / \`h-dvh\` / \`min-h-dvh\` / \`max-w-{sm,md,lg,xl,2xl}\` |
| **ArteOdyssey token-bound colors** | \`bg-bg-base\`, \`bg-bg-surface\`, \`text-fg-base\`, \`text-fg-mute\`, \`border-border-mute\` |
| Borders / radius | \`border\` / \`border-{t,b,l,r}\` / \`rounded-{sm,md,lg,xl,2xl,full}\` |
| Overflow | \`overflow-{hidden,auto,y-auto,x-auto}\` |

**Explicitly excluded**: raw palette (\`bg-red-500\`), arbitrary sizes (\`gap-[37px]\`), important / deep selectors. The allowlist is the design-system safety boundary; growing it is a deliberate decision per token.

### Registry (\`registry.tsx\`)

\`layoutElementRenderer\` factory wires each tag to a thin \`createElement\` passthrough. Zod has already validated \`className\` upstream so the renderer trusts it. \`displayName\` set so React devtools shows \`divRenderer\` etc.

### Codegen (\`code-output.ts\`)

- \`HTML_TAGS\` set drives two behaviors: per-tag formatters that emit the element verbatim (\`<div className="flex gap-4">…\`), and the import-line filter so native tags never appear in \`import { … } from '@k8o/arte-odyssey'\`.
- Generated TSX matches what an ArteOdyssey author would write by hand — no invented primitives like \`Stack\` / \`Box\`.

## Test plan

- [x] \`pnpm typecheck\` / \`pnpm check\` / \`pnpm test\` (15/15 incl. allowlist accept / reject) pass
- [x] **Live (Gemini)**: \`"a header section with a title card, then a main section containing two cards side by side, each with a primary button labeled Save"\` → iframe renders \`1 header + 1 main + 7 layout divs + 3 Cards + 2 Save Buttons\`. Real composition, not nested-Card workarounds.

Implements ADR-012 (in local \`docs/decisions.md\`).