### PR TITLE
prototype: extract decoro-catalog.json from local ArteOdyssey (F2 prototype, do not merge)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,18 @@
     "check:write": "vp check --fix"
   },
   "devDependencies": {
+    "@babel/parser": "7.29.2",
+    "@babel/traverse": "7.29.0",
+    "@babel/types": "7.29.0",
     "@commitlint/cli": "20.5.0",
     "@commitlint/config-conventional": "20.5.0",
     "@k8o/oxc-config": "0.1.2",
     "@oxlint/plugins": "1.61.0",
+    "@types/babel__traverse": "7.28.0",
     "@types/node": "24.12.2",
     "oxlint-tailwindcss": "0.6.3",
+    "react-docgen-typescript": "2.4.0",
+    "tsx": "4.21.0",
     "typescript": "6.0.3",
     "vite-plus": "catalog:"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,15 @@ importers:
 
   .:
     devDependencies:
+      '@babel/parser':
+        specifier: 7.29.2
+        version: 7.29.2
+      '@babel/traverse':
+        specifier: 7.29.0
+        version: 7.29.0
+      '@babel/types':
+        specifier: 7.29.0
+        version: 7.29.0
       '@commitlint/cli':
         specifier: 20.5.0
         version: 20.5.0(@types/node@24.12.2)(conventional-commits-parser@6.4.0)(typescript@6.0.3)
@@ -68,18 +77,27 @@ importers:
       '@oxlint/plugins':
         specifier: 1.61.0
         version: 1.61.0
+      '@types/babel__traverse':
+        specifier: 7.28.0
+        version: 7.28.0
       '@types/node':
         specifier: 24.12.2
         version: 24.12.2
       oxlint-tailwindcss:
         specifier: 0.6.3
         version: 0.6.3(@oxlint/plugins@1.61.0)
+      react-docgen-typescript:
+        specifier: 2.4.0
+        version: 2.4.0(typescript@6.0.3)
+      tsx:
+        specifier: 4.21.0
+        version: 4.21.0
       typescript:
         specifier: 6.0.3
         version: 6.0.3
       vite-plus:
         specifier: 'catalog:'
-        version: 0.1.19(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jiti@2.6.1)(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))
+        version: 0.1.19(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
 
   apps/web:
     dependencies:
@@ -174,7 +192,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 6.0.1(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))
+        version: 6.0.1(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
       react-dom:
         specifier: 'catalog:'
         version: 19.2.5(react@19.2.5)
@@ -241,8 +259,37 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@commitlint/cli@20.5.0':
@@ -334,6 +381,162 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -1169,6 +1372,9 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -1469,6 +1675,15 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -1500,6 +1715,11 @@ packages:
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -1546,6 +1766,9 @@ packages:
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
   git-raw-commits@5.0.1:
     resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
@@ -1603,6 +1826,11 @@ packages:
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
     hasBin: true
 
   json-parse-even-better-errors@2.3.1:
@@ -1775,6 +2003,9 @@ packages:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
 
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -1865,6 +2096,11 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  react-docgen-typescript@2.4.0:
+    resolution: {integrity: sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==}
+    peerDependencies:
+      typescript: '>= 4.3.x'
+
   react-dom@19.2.5:
     resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
     peerDependencies:
@@ -1898,6 +2134,9 @@ packages:
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
   rolldown@1.0.0-rc.17:
     resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
@@ -1998,6 +2237,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
@@ -2150,7 +2394,46 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-string-parser@7.27.1': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/parser@7.29.2':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
 
   '@commitlint/cli@20.5.0(@types/node@24.12.2)(conventional-commits-parser@6.4.0)(typescript@6.0.3)':
     dependencies:
@@ -2288,6 +2571,84 @@ snapshots:
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@floating-ui/core@1.7.5':
@@ -2837,6 +3198,10 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -2872,12 +3237,12 @@ snapshots:
 
   '@vercel/oidc@3.2.0': {}
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.10(@types/node@24.12.2)(jiti@2.6.1)
+      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)
 
-  '@voidzero-dev/vite-plus-core@0.1.19(@types/node@24.12.2)(jiti@2.6.1)(typescript@6.0.3)':
+  '@voidzero-dev/vite-plus-core@0.1.19(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(typescript@6.0.3)':
     dependencies:
       '@oxc-project/runtime': 0.126.0
       '@oxc-project/types': 0.126.0
@@ -2885,8 +3250,10 @@ snapshots:
       postcss: 8.5.12
     optionalDependencies:
       '@types/node': 24.12.2
+      esbuild: 0.27.7
       fsevents: 2.3.3
       jiti: 2.6.1
+      tsx: 4.21.0
       typescript: 6.0.3
 
   '@voidzero-dev/vite-plus-darwin-arm64@0.1.19':
@@ -2907,11 +3274,11 @@ snapshots:
   '@voidzero-dev/vite-plus-linux-x64-musl@0.1.19':
     optional: true
 
-  '@voidzero-dev/vite-plus-test@0.1.19(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jiti@2.6.1)(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))':
+  '@voidzero-dev/vite-plus-test@0.1.19(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@voidzero-dev/vite-plus-core': 0.1.19(@types/node@24.12.2)(jiti@2.6.1)(typescript@6.0.3)
+      '@voidzero-dev/vite-plus-core': 0.1.19(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(typescript@6.0.3)
       es-module-lexer: 1.7.0
       obug: 2.1.1
       pixelmatch: 7.1.0
@@ -2921,7 +3288,7 @@ snapshots:
       tinybench: 2.9.0
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
-      vite: 8.0.10(@types/node@24.12.2)(jiti@2.6.1)
+      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)
       ws: 8.20.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
@@ -3051,6 +3418,10 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
@@ -3078,6 +3449,35 @@ snapshots:
 
   es-module-lexer@1.7.0: {}
 
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
   escalade@3.2.0: {}
 
   eventsource-parser@3.0.8: {}
@@ -3103,6 +3503,10 @@ snapshots:
     optional: true
 
   get-caller-file@2.0.5: {}
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   git-raw-commits@5.0.1(conventional-commits-parser@6.4.0):
     dependencies:
@@ -3162,6 +3566,8 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsesc@3.1.0: {}
 
   json-parse-even-better-errors@2.3.1: {}
 
@@ -3305,6 +3711,8 @@ snapshots:
 
   mrmime@2.0.1: {}
 
+  ms@2.1.3: {}
+
   nanoid@3.3.11: {}
 
   next@16.2.4(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
@@ -3433,6 +3841,10 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  react-docgen-typescript@2.4.0(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
+
   react-dom@19.2.5(react@19.2.5):
     dependencies:
       react: 19.2.5
@@ -3457,6 +3869,8 @@ snapshots:
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
 
   rolldown@1.0.0-rc.17:
     dependencies:
@@ -3585,6 +3999,13 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   typescript@6.0.3: {}
 
   undici-types@7.16.0: {}
@@ -3622,11 +4043,11 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plus@0.1.19(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jiti@2.6.1)(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1)):
+  vite-plus@0.1.19(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)):
     dependencies:
       '@oxc-project/types': 0.126.0
-      '@voidzero-dev/vite-plus-core': 0.1.19(@types/node@24.12.2)(jiti@2.6.1)(typescript@6.0.3)
-      '@voidzero-dev/vite-plus-test': 0.1.19(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jiti@2.6.1)(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))
+      '@voidzero-dev/vite-plus-core': 0.1.19(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(typescript@6.0.3)
+      '@voidzero-dev/vite-plus-test': 0.1.19(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
       oxfmt: 0.45.0
       oxlint: 1.60.0(oxlint-tsgolint@0.21.1)
       oxlint-tsgolint: 0.21.1
@@ -3669,7 +4090,7 @@ snapshots:
       - vite
       - yaml
 
-  vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1):
+  vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -3678,8 +4099,10 @@ snapshots:
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 24.12.2
+      esbuild: 0.27.7
       fsevents: 2.3.3
       jiti: 2.6.1
+      tsx: 4.21.0
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/scripts/extract-from-arte-odyssey.ts
+++ b/scripts/extract-from-arte-odyssey.ts
@@ -1,0 +1,438 @@
+/**
+ * F2 prototype: extract a `decoro-catalog.json` from a local ArteOdyssey
+ * checkout.
+ *
+ * In the eventual first-release shape (per ADR-011 / issue #25), this
+ * extraction lives in the ArteOdyssey repo itself, runs after
+ * `pnpm build-storybook`, and uploads the JSON to Chromatic alongside the
+ * static build. Decoro's F1 generator (issue #24) then fetches it.
+ *
+ * Today the script is here so we can iterate on the JSON shape and the
+ * extraction itself without an ArteOdyssey-side PR. It is **not** wired into
+ * any Decoro workflow.
+ *
+ * Usage:
+ *   pnpm tsx scripts/extract-from-arte-odyssey.ts \
+ *     [--arte-odyssey ../ArteOdyssey/packages/arte-odyssey] \
+ *     [--out /tmp/decoro-catalog.json]
+ *
+ * The strict no-unsafe-* rules are disabled file-wide because this script
+ * walks Babel ASTs and react-docgen-typescript output — both intentionally
+ * `any`-typed at the boundary. The prototype runs once locally and is not
+ * loaded by any production code path.
+ */
+/* oxlint-disable typescript/no-non-null-assertion typescript/no-unsafe-return typescript/no-unsafe-call typescript/no-unsafe-member-access typescript/no-unsafe-argument typescript/no-unsafe-assignment typescript/no-explicit-any typescript/no-redundant-type-constituents eslint/no-console */
+
+import { readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { argv, exit } from 'node:process';
+
+import { parse as parseBabel } from '@babel/parser';
+import babelTraverse from '@babel/traverse';
+import * as t from '@babel/types';
+import { withDefaultConfig } from 'react-docgen-typescript';
+
+const traverse =
+  (babelTraverse as unknown as { default?: typeof babelTraverse }).default ??
+  babelTraverse;
+
+type CliFlags = { arteOdyssey: string; out: string };
+
+const parseFlags = (args: string[]): CliFlags => {
+  const flags: CliFlags = {
+    arteOdyssey: resolve('../ArteOdyssey/packages/arte-odyssey'),
+    out: resolve('/tmp/decoro-catalog.json'),
+  };
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '--arte-odyssey') {
+      flags.arteOdyssey = resolve(args[++i] ?? '');
+    } else if (arg === '--out') {
+      flags.out = resolve(args[++i] ?? '');
+    }
+  }
+  return flags;
+};
+
+const walkFiles = (root: string, predicate: (path: string) => boolean) => {
+  const out: string[] = [];
+  const stack: string[] = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      const st = statSync(full);
+      if (st.isDirectory()) {
+        if (entry === 'node_modules' || entry.startsWith('.')) continue;
+        stack.push(full);
+      } else if (st.isFile() && predicate(full)) {
+        out.push(full);
+      }
+    }
+  }
+  return out;
+};
+
+const isComponentFile = (path: string) =>
+  path.endsWith('.tsx') &&
+  !path.endsWith('.stories.tsx') &&
+  !path.endsWith('.test.tsx');
+
+const isStoryFile = (path: string) => path.endsWith('.stories.tsx');
+
+/**
+ * Read `src/components/index.ts` (and any `*Icon` filtering rules) to derive
+ * the set of identifiers ArteOdyssey actually publishes. Anything else found
+ * by walking the source tree is an internal subcomponent and should be left
+ * out of the catalog so the LLM only sees the official surface.
+ */
+const readPublicExports = (arteOdysseyRoot: string): Set<string> => {
+  const indexPath = join(arteOdysseyRoot, 'src/components/index.ts');
+  const src = readFileSync(indexPath, 'utf8');
+  const ast = parseBabel(src, {
+    sourceType: 'module',
+    plugins: ['typescript'],
+  });
+  const names = new Set<string>();
+  traverse(ast, {
+    ExportNamedDeclaration(path) {
+      for (const spec of path.node.specifiers) {
+        if (t.isExportSpecifier(spec) && t.isIdentifier(spec.exported)) {
+          names.add(spec.exported.name);
+        }
+      }
+    },
+  });
+  return names;
+};
+
+/**
+ * Filter rules applied on top of public exports:
+ * - Drop everything that ends in `Icon` (40+ visual icons; not useful as
+ *   AI-pickable layout components).
+ * - Drop hooks (anything starting with `use`).
+ * - Drop providers / context wrappers (anything ending in `Provider`).
+ */
+const isCatalogCandidate = (name: string): boolean => {
+  if (name.endsWith('Icon')) return false;
+  if (name.startsWith('use')) return false;
+  if (name.endsWith('Provider')) return false;
+  if (name === 'Logo') return false;
+  return true;
+};
+
+type DecoroCatalog = {
+  schemaVersion: 1;
+  library: { name: string; version: string };
+  components: ComponentEntry[];
+};
+
+type ComponentEntry = {
+  name: string;
+  importPath: string;
+  description: string;
+  sourcePath: string;
+  props: PropEntry[];
+  examples: ExampleEntry[];
+};
+
+type PropEntry = {
+  name: string;
+  description: string;
+  required: boolean;
+  defaultValue: unknown;
+  type: PropType;
+};
+
+type PropType =
+  | { kind: 'enum'; values: string[] }
+  | { kind: 'string' }
+  | { kind: 'number' }
+  | { kind: 'boolean' }
+  | { kind: 'union'; raw: string }
+  | { kind: 'unknown'; raw: string };
+
+type ExampleEntry = {
+  name: string;
+  args: Record<string, unknown>;
+};
+
+type DocgenPropType = {
+  name: string;
+  value?: ReadonlyArray<{ value: string }>;
+  raw?: string;
+};
+
+const classifyType = (typeInfo: DocgenPropType): PropType => {
+  const name = typeInfo.name.trim();
+  // react-docgen-typescript reports literal unions as `name: 'enum'` with the
+  // members in `value: [{ value: '"primary"' }, ...]`.
+  if (name === 'enum' && Array.isArray(typeInfo.value)) {
+    const literals = typeInfo.value
+      .map((v) => v.value.trim())
+      .filter((v) => /^("[^"]*"|'[^']*'|true|false|null|undefined)$/.test(v));
+    const stringLits = literals
+      .filter((v) => /^("[^"]*"|'[^']*')$/.test(v))
+      .map((v) => v.slice(1, -1));
+    if (stringLits.length === literals.length && stringLits.length > 0) {
+      return { kind: 'enum', values: stringLits };
+    }
+  }
+  if (name === 'string') return { kind: 'string' };
+  if (name === 'number') return { kind: 'number' };
+  if (name === 'boolean') return { kind: 'boolean' };
+  if (name.includes('|')) return { kind: 'union', raw: name };
+  return { kind: 'unknown', raw: typeInfo.raw ?? name };
+};
+
+const extractComponents = (
+  arteOdysseyRoot: string,
+  componentFiles: string[],
+): Map<string, ComponentEntry> => {
+  const tsconfigPath = join(arteOdysseyRoot, 'tsconfig.json');
+  const parser = withDefaultConfig({
+    shouldExtractLiteralValuesFromEnum: true,
+    shouldRemoveUndefinedFromOptional: true,
+    savePropValueAsString: false,
+    propFilter: (prop) => {
+      if (prop.parent === undefined) return true;
+      // Drop props inherited from React/HTML (HTMLAttributes etc.) — we only
+      // want the component-specific surface in the AI catalog.
+      return !prop.parent.fileName.includes('node_modules');
+    },
+  });
+
+  const componentsByName = new Map<string, ComponentEntry>();
+  let parsed = 0;
+
+  for (const file of componentFiles) {
+    let docs;
+    try {
+      docs = parser.parse(file);
+    } catch (err) {
+      console.warn(
+        `[skip] react-docgen-typescript failed for ${relative(arteOdysseyRoot, file)}: ${(err as Error).message}`,
+      );
+      continue;
+    }
+    for (const doc of docs) {
+      if (componentsByName.has(doc.displayName)) continue;
+      const props: PropEntry[] = Object.entries(doc.props).map(
+        ([name, info]) => ({
+          name,
+          description: info.description,
+          required: info.required,
+          defaultValue: info.defaultValue?.value,
+          type: classifyType(info.type as DocgenPropType),
+        }),
+      );
+      componentsByName.set(doc.displayName, {
+        name: doc.displayName,
+        importPath: '@k8o/arte-odyssey',
+        description: doc.description,
+        sourcePath: relative(arteOdysseyRoot, file),
+        props,
+        examples: [],
+      });
+      parsed += 1;
+    }
+    void tsconfigPath;
+  }
+
+  console.log(`[info] react-docgen-typescript: parsed ${parsed} components`);
+  return componentsByName;
+};
+
+const extractStoryArgs = (
+  arteOdysseyRoot: string,
+  storyFiles: string[],
+  componentsByName: Map<string, ComponentEntry>,
+) => {
+  let attached = 0;
+  let skipped = 0;
+  for (const file of storyFiles) {
+    let ast;
+    try {
+      const src = readFileSync(file, 'utf8');
+      ast = parseBabel(src, {
+        sourceType: 'module',
+        plugins: ['typescript', 'jsx'],
+      });
+    } catch (err) {
+      console.warn(
+        `[skip] babel parse failed for ${relative(arteOdysseyRoot, file)}: ${(err as Error).message}`,
+      );
+      skipped += 1;
+      continue;
+    }
+
+    let componentName: string | undefined;
+    let metaArgs: Record<string, unknown> = {};
+    const stories: ExampleEntry[] = [];
+
+    traverse(ast, {
+      // `const meta: Meta<typeof Button> = { component: Button, args: {...} }`
+      VariableDeclarator(path) {
+        if (
+          t.isIdentifier(path.node.id) &&
+          path.node.id.name === 'meta' &&
+          t.isObjectExpression(path.node.init)
+        ) {
+          for (const prop of path.node.init.properties) {
+            if (!t.isObjectProperty(prop)) continue;
+            const key = propKeyName(prop.key);
+            if (key === 'component' && t.isIdentifier(prop.value)) {
+              componentName = prop.value.name;
+            } else if (key === 'args' && t.isObjectExpression(prop.value)) {
+              metaArgs = literalObject(prop.value);
+            }
+          }
+        }
+      },
+      // `export const Primary: Story = { args: {...} }`
+      ExportNamedDeclaration(path) {
+        if (!t.isVariableDeclaration(path.node.declaration)) return;
+        for (const declarator of path.node.declaration.declarations) {
+          if (
+            !t.isIdentifier(declarator.id) ||
+            !t.isObjectExpression(declarator.init)
+          )
+            continue;
+          const storyName = declarator.id.name;
+          if (storyName === 'meta') continue;
+          const storyArgs = pickArgs(declarator.init);
+          stories.push({
+            name: storyName,
+            args: { ...metaArgs, ...storyArgs },
+          });
+        }
+      },
+    });
+
+    if (componentName === undefined) {
+      console.warn(
+        `[skip] no \`component\` field in ${relative(arteOdysseyRoot, file)}`,
+      );
+      skipped += 1;
+      continue;
+    }
+
+    const entry = componentsByName.get(componentName);
+    if (entry === undefined) {
+      console.warn(
+        `[skip] story for unknown component "${componentName}" in ${relative(arteOdysseyRoot, file)}`,
+      );
+      skipped += 1;
+      continue;
+    }
+    entry.examples.push(...stories);
+    attached += stories.length;
+  }
+  console.log(
+    `[info] stories: attached ${attached} examples (${skipped} files skipped)`,
+  );
+};
+
+const propKeyName = (key: t.Expression | t.PrivateName): string | undefined => {
+  if (t.isIdentifier(key)) return key.name;
+  if (t.isStringLiteral(key)) return key.value;
+  return undefined;
+};
+
+const pickArgs = (obj: t.ObjectExpression): Record<string, unknown> => {
+  for (const prop of obj.properties) {
+    if (!t.isObjectProperty(prop)) continue;
+    if (propKeyName(prop.key) === 'args' && t.isObjectExpression(prop.value)) {
+      return literalObject(prop.value);
+    }
+  }
+  return {};
+};
+
+const literalObject = (obj: t.ObjectExpression): Record<string, unknown> => {
+  const out: Record<string, unknown> = {};
+  for (const prop of obj.properties) {
+    if (!t.isObjectProperty(prop)) continue;
+    const key = propKeyName(prop.key);
+    if (key === undefined) continue;
+    const value = literalValue(prop.value);
+    if (value !== UNRESOLVABLE) out[key] = value;
+  }
+  return out;
+};
+
+const UNRESOLVABLE = Symbol('unresolvable');
+
+const literalValue = (
+  node: t.Expression | t.PatternLike,
+): unknown | typeof UNRESOLVABLE => {
+  if (t.isStringLiteral(node)) return node.value;
+  if (t.isNumericLiteral(node)) return node.value;
+  if (t.isBooleanLiteral(node)) return node.value;
+  if (t.isNullLiteral(node)) return null;
+  if (t.isArrayExpression(node)) {
+    const out: unknown[] = [];
+    for (const element of node.elements) {
+      if (element === null) continue;
+      if (t.isSpreadElement(element)) continue;
+      const v = literalValue(element);
+      if (v === UNRESOLVABLE) continue;
+      out.push(v);
+    }
+    return out;
+  }
+  if (t.isObjectExpression(node)) return literalObject(node);
+  // Identifiers / function expressions / icon JSX etc. — skip silently.
+  return UNRESOLVABLE;
+};
+
+const main = () => {
+  const flags = parseFlags(argv.slice(2));
+  console.log(`[info] arte-odyssey root: ${flags.arteOdyssey}`);
+  console.log(`[info] output: ${flags.out}`);
+
+  let pkg;
+  try {
+    pkg = JSON.parse(
+      readFileSync(join(flags.arteOdyssey, 'package.json'), 'utf8'),
+    ) as { name: string; version: string };
+  } catch (err) {
+    console.error(
+      `[fatal] could not read ${join(flags.arteOdyssey, 'package.json')}: ${(err as Error).message}`,
+    );
+    exit(1);
+  }
+
+  const srcRoot = join(flags.arteOdyssey, 'src/components');
+  const componentFiles = walkFiles(srcRoot, isComponentFile);
+  const storyFiles = walkFiles(srcRoot, isStoryFile);
+  const publicExports = readPublicExports(flags.arteOdyssey);
+  const catalogTargets = new Set(
+    [...publicExports].filter((n) => isCatalogCandidate(n)),
+  );
+  console.log(
+    `[info] discovered ${componentFiles.length} components, ${storyFiles.length} stories`,
+  );
+  console.log(
+    `[info] public exports: ${publicExports.size}, catalog targets after filter: ${catalogTargets.size}`,
+  );
+
+  const componentsByName = extractComponents(flags.arteOdyssey, componentFiles);
+  extractStoryArgs(flags.arteOdyssey, storyFiles, componentsByName);
+
+  const catalog: DecoroCatalog = {
+    schemaVersion: 1,
+    library: { name: pkg.name, version: pkg.version },
+    components: [...componentsByName.values()]
+      .filter((c) => catalogTargets.has(c.name))
+      .toSorted((a, b) => a.name.localeCompare(b.name)),
+  };
+
+  writeFileSync(flags.out, `${JSON.stringify(catalog, null, 2)}\n`);
+  console.log(
+    `[done] wrote ${catalog.components.length} components to ${flags.out}`,
+  );
+  void dirname;
+};
+
+main();


### PR DESCRIPTION
## Summary

**Draft / prototype, not for merge in this form.** F2's extraction logic, run locally against a checkout of ArteOdyssey at \`../ArteOdyssey\`, so we can iterate on the JSON shape and the generator design without round-tripping through an ArteOdyssey-side PR. Eventually moves to ArteOdyssey's \`build-storybook\` step (issue #25 / ADR-011).

## What it does

\`scripts/extract-from-arte-odyssey.ts\`:

1. Walks \`../ArteOdyssey/packages/arte-odyssey/src/components/\`.
2. Runs \`react-docgen-typescript\` on component \`.tsx\` files; classifies each prop as enum (with extracted literal values), string, number, boolean, union, or unknown.
3. Filters to ArteOdyssey's \`index.ts\` public exports, then drops Icons / hooks / Providers / Logo so the LLM only sees the composable surface.
4. Parses \`*.stories.tsx\` via \`@babel/parser\` to extract each story's \`args\` (merged with \`meta.args\`) as an example.
5. Outputs a single JSON file matching the shape sketched in #25.

## Local run output

\`\`\`
[info] discovered 61 components, 47 stories
[info] public exports: 52, catalog targets after filter: 46
[info] react-docgen-typescript: parsed 118 components
[info] stories: attached 144 examples (12 files skipped)
[done] wrote 37 components to /tmp/decoro-catalog.json
\`\`\`

The 37 catalog components include all the pieces needed for the \`mvp-scope.md\` "build me a login form" stretch acceptance: TextField (4 examples), PasswordInput (4), Form (2), FormControl (7), Heading (6).

\`Button\` is fully extracted with per-prop enum literal values (e.g. \`color: ['primary', 'secondary', 'gray']\`, \`variant: ['contained', 'outlined', 'skeleton']\`) and 17 examples covering every named story.

## What this validates

- The Storybook-driven approach (ADR-011 revised) actually produces useful Catalog data without needing the full Chromatic build pipeline.
- The JSON shape sketched in #25 is workable end-to-end.
- 12 stories use a "render multiple components" pattern that does not name a single \`component\` in their meta — those need a thin convention update on the ArteOdyssey side, OR Decoro can derive the component from the file path. Either is fine.

## Why "do not merge"

- Lives in Decoro temporarily; in the real F2 (#25) it goes into the ArteOdyssey repo and runs after \`pnpm build-storybook\`.
- The strict \`no-unsafe-*\` / \`no-console\` rules are file-wide-disabled because the script is a one-off CLI walking dynamic ASTs. Production code in either repo would not look like this.
- F1 (#24) needs a separate, real PR to consume the JSON. This one is just the producer-side proof of concept.

## Next

- F2 PR opens against ArteOdyssey: refactor the extraction into ArteOdyssey's build pipeline.
- F1 PR opens against Decoro: implement the consumer that fetches from Chromatic and emits \`catalog.generated.ts\`.
- Close this draft when both above land.