### PR TITLE
refactor(web): extract shared shell building blocks (Tier 1 cleanup)

### DIFF
--- a/apps/web/decoro.config.ts
+++ b/apps/web/decoro.config.ts
@@ -1,3 +1,4 @@
+import { arteOdysseyAdapter } from '@decoro/adapter-arte-odyssey';
 import type { LlmConfig } from '@decoro/llm-config';
 
 /**
@@ -39,6 +40,23 @@ export const llm: LlmConfig = {
   model: 'gemini-2.5-flash',
   apiKey: process.env['GOOGLE_GENERATIVE_AI_API_KEY'],
 };
+
+/**
+ * Adapter binding. Pinned here so the rest of `apps/web` consumes the
+ * adapter through the abstract `Adapter` contract — `code-panel.tsx`,
+ * `preview/page.tsx`, and `/api/generate` all import this rather than
+ * `@decoro/adapter-arte-odyssey` directly. Switching to a future
+ * `@decoro/adapter-mui` etc. is a one-line change here, no consumer churn.
+ *
+ * Per ADR-004 we deliberately do not introduce a `defineConfig({ adapter,
+ * llm })` wrapper — there's only one adapter today and one config field
+ * pattern is enough for both bindings.
+ */
+// Typed as `typeof arteOdysseyAdapter` (not the bare `Adapter` interface)
+// so the registry's component type stays narrow — `Adapter` defaults
+// `TComponent` to `unknown`, which json-render's `ComponentRegistry` would
+// then refuse. Concrete adapter exports preserve the right specialization.
+export const adapter = arteOdysseyAdapter;
 
 /**
  * Share-snapshot configuration (see ADR-013).

--- a/apps/web/src/app/api/generate/route.ts
+++ b/apps/web/src/app/api/generate/route.ts
@@ -5,45 +5,25 @@ import { type ModelMessage, streamText } from 'ai';
 import { z } from 'zod';
 
 import { llm } from '../../../../decoro.config.ts';
+import { jsonError } from '../../../lib/api-response.ts';
+import {
+  MAX_MESSAGE_CHARS,
+  MAX_MESSAGES,
+  specSchema,
+  toSpec,
+} from '../../../lib/spec-schema.ts';
 
-// Limits sized for "self-hosted, trusted-network MVP". Generous enough that
-// real chat sessions never bump them, tight enough that a runaway client or
-// hostile insider cannot DoS the endpoint or rack up an unbounded LLM bill.
-const MAX_MESSAGES = 50;
-const MAX_MESSAGE_CHARS = 4000;
-const MAX_SPEC_ELEMENTS = 200;
-const MAX_ELEMENT_CHILDREN = 50;
-const MAX_COMPONENT_TYPE_CHARS = 50;
-
+// `messageSchema` shape is local to this route — the LLM API takes
+// `{role, content}` with a `system` role; the chat / share path uses
+// `{id, role, text}` (see share-types.ts). Same per-message char limit.
 const messageSchema = z.object({
   role: z.enum(['user', 'assistant', 'system']),
   content: z.string().min(1).max(MAX_MESSAGE_CHARS),
 });
 
-const elementSchema = z.object({
-  type: z.string().min(1).max(MAX_COMPONENT_TYPE_CHARS),
-  props: z.record(z.string(), z.unknown()),
-  children: z.array(z.string()).max(MAX_ELEMENT_CHILDREN),
-  visible: z.unknown().optional(),
-});
-
-const specSchema = z
-  .object({
-    root: z.string(),
-    elements: z
-      .record(z.string(), elementSchema)
-      .refine(
-        (e) => Object.keys(e).length <= MAX_SPEC_ELEMENTS,
-        `spec exceeds max ${MAX_SPEC_ELEMENTS.toString()} elements`,
-      ),
-    state: z.unknown().optional(),
-  })
-  .nullable()
-  .optional();
-
 const requestSchema = z.object({
   messages: z.array(messageSchema).min(1).max(MAX_MESSAGES),
-  currentSpec: specSchema,
+  currentSpec: specSchema.nullable().optional(),
 });
 
 // Ask the model to prefix the JSONL stream with a single short natural-
@@ -70,12 +50,6 @@ const systemPrompt = [
 
 const isMeaningfulSpec = (spec: Spec | null | undefined): spec is Spec =>
   spec !== null && spec !== undefined && spec.root !== '';
-
-const jsonError = (status: number, message: string) =>
-  new Response(JSON.stringify({ message }), {
-    status,
-    headers: { 'content-type': 'application/json' },
-  });
 
 /**
  * POST /api/generate streams the LLM's raw text output back to the client.
@@ -105,13 +79,10 @@ export const POST = async (req: Request) => {
     return jsonError(400, parsed.error.message);
   }
 
-  // The zod schema enforces shape and size limits; downstream consumers
-  // (json-render's buildUserPrompt, the registry) accept the wider Spec
-  // type. Cast is safe — anything the schema accepts is structurally a Spec.
-  const augmented = augmentLastUserMessage(
-    parsed.data.messages,
-    (parsed.data.currentSpec ?? null) as Spec | null,
-  );
+  const currentSpec = parsed.data.currentSpec
+    ? toSpec(parsed.data.currentSpec)
+    : null;
+  const augmented = augmentLastUserMessage(parsed.data.messages, currentSpec);
 
   try {
     const result = streamText({

--- a/apps/web/src/app/api/generate/route.ts
+++ b/apps/web/src/app/api/generate/route.ts
@@ -1,10 +1,9 @@
-import { arteOdysseyAdapter } from '@decoro/adapter-arte-odyssey';
 import { createModel } from '@decoro/llm-config';
 import { type Spec, buildUserPrompt } from '@json-render/core';
 import { type ModelMessage, streamText } from 'ai';
 import { z } from 'zod';
 
-import { llm } from '../../../../decoro.config.ts';
+import { adapter, llm } from '../../../../decoro.config.ts';
 import { jsonError } from '../../../lib/api-response.ts';
 import {
   MAX_MESSAGE_CHARS,
@@ -40,10 +39,10 @@ const responsePreambleInstruction = [
 ].join('\n');
 
 const systemPrompt = [
-  arteOdysseyAdapter.catalog.prompt({ mode: 'standalone' }),
+  adapter.catalog.prompt({ mode: 'standalone' }),
   '',
   'Library design principles:',
-  arteOdysseyAdapter.metadata.designPrinciples,
+  adapter.metadata.designPrinciples,
   '',
   responsePreambleInstruction,
 ].join('\n');

--- a/apps/web/src/app/api/share/[id]/route.ts
+++ b/apps/web/src/app/api/share/[id]/route.ts
@@ -1,3 +1,4 @@
+import { jsonError } from '../../../../lib/api-response.ts';
 import { getSnapshot } from '../../../../lib/share-store.ts';
 
 /**
@@ -12,12 +13,7 @@ export const GET = async (
 ) => {
   const { id } = await ctx.params;
   const snapshot = await getSnapshot(id);
-  if (!snapshot) {
-    return new Response(JSON.stringify({ message: 'not found' }), {
-      status: 404,
-      headers: { 'content-type': 'application/json' },
-    });
-  }
+  if (!snapshot) return jsonError(404, 'not found');
   return new Response(JSON.stringify(snapshot), {
     status: 200,
     headers: {

--- a/apps/web/src/app/api/share/route.ts
+++ b/apps/web/src/app/api/share/route.ts
@@ -1,12 +1,7 @@
 import { share } from '../../../../decoro.config.ts';
+import { jsonError } from '../../../lib/api-response.ts';
 import { SnapshotExistsError, putSnapshot } from '../../../lib/share-store.ts';
 import { newShareId, snapshotInputSchema } from '../../../lib/share-types.ts';
-
-const jsonError = (status: number, message: string) =>
-  new Response(JSON.stringify({ message }), {
-    status,
-    headers: { 'content-type': 'application/json' },
-  });
 
 /**
  * Per-IP rate limit. Best-effort only.

--- a/apps/web/src/app/preview/page.tsx
+++ b/apps/web/src/app/preview/page.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { arteOdysseyAdapter } from '@decoro/adapter-arte-odyssey';
 import type { Spec } from '@json-render/core';
 import { JSONUIProvider, Renderer } from '@json-render/react';
 import { SparklesIcon } from '@k8o/arte-odyssey';
 import { useEffect, useState } from 'react';
 
+import { adapter } from '../../../decoro.config.ts';
 import {
   type PreviewOutboundMessage,
   isPreviewMessage,
@@ -37,8 +37,8 @@ const PreviewPage = () => {
     <div className="bg-bg-base text-fg-base min-h-dvh">
       {spec ? (
         <div className="p-6">
-          <JSONUIProvider registry={arteOdysseyAdapter.registry}>
-            <Renderer spec={spec} registry={arteOdysseyAdapter.registry} />
+          <JSONUIProvider registry={adapter.registry}>
+            <Renderer spec={spec} registry={adapter.registry} />
           </JSONUIProvider>
         </div>
       ) : (

--- a/apps/web/src/components/app-header.tsx
+++ b/apps/web/src/components/app-header.tsx
@@ -1,0 +1,28 @@
+import { Heading, SparklesIcon } from '@k8o/arte-odyssey';
+import type { ReactNode } from 'react';
+
+type Props = {
+  /** Tagline shown next to the wordmark. */
+  tagline: string;
+  /** Right-aligned slot — Share button on `/`, "Open Decoro" link on `/share/[id]`. */
+  rightSlot?: ReactNode;
+};
+
+/**
+ * Brand chrome shared by `/` (HomeShell) and `/share/[id]` (ShareView).
+ * The wordmark + SparklesIcon are fixed; tagline and right-slot vary per page.
+ */
+export const AppHeader = ({ tagline, rightSlot }: Props) => (
+  <header className="bg-bg-base border-border-subtle flex items-center justify-between border-b px-6 py-4">
+    <div className="flex items-center gap-3">
+      <span className="text-primary-fg" aria-hidden="true">
+        <SparklesIcon size="lg" />
+      </span>
+      <div className="flex items-baseline gap-3">
+        <Heading type="h1">Decoro</Heading>
+        <p className="text-fg-mute text-sm">{tagline}</p>
+      </div>
+    </div>
+    {rightSlot}
+  </header>
+);

--- a/apps/web/src/components/chat-pane.tsx
+++ b/apps/web/src/components/chat-pane.tsx
@@ -10,11 +10,9 @@ import {
 } from '@k8o/arte-odyssey';
 import { useState } from 'react';
 
-export type ChatMessage = {
-  id: string;
-  role: 'user' | 'assistant';
-  text: string;
-};
+import type { ChatMessage } from '../lib/share-types.ts';
+
+export type { ChatMessage };
 
 type Props = {
   messages: ChatMessage[];

--- a/apps/web/src/components/chat-pane.tsx
+++ b/apps/web/src/components/chat-pane.tsx
@@ -10,9 +10,7 @@ import {
 } from '@k8o/arte-odyssey';
 import { useState } from 'react';
 
-import type { ChatMessage } from '../lib/share-types.ts';
-
-export type { ChatMessage };
+import type { ChatMessage } from '../lib/chat-types.ts';
 
 type Props = {
   messages: ChatMessage[];

--- a/apps/web/src/components/code-panel.tsx
+++ b/apps/web/src/components/code-panel.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { arteOdysseyAdapter } from '@decoro/adapter-arte-odyssey';
 import type { Spec } from '@json-render/core';
 import { Button, CopyIcon, SparklesIcon } from '@k8o/arte-odyssey';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { codeToHtml } from 'shiki';
+
+import { adapter } from '../../decoro.config.ts';
 
 type Props = {
   spec: Spec | null;
@@ -32,7 +33,7 @@ export const CodePanel = ({ spec }: Props) => {
   const code = useMemo<CodeState>(() => {
     if (spec === null) return { kind: 'empty' };
     try {
-      const value = arteOdysseyAdapter.codeOutput.generate(spec);
+      const value = adapter.codeOutput.generate(spec);
       return value === '' ? { kind: 'empty' } : { kind: 'ok', value };
     } catch (err) {
       return {

--- a/apps/web/src/components/code-panel.tsx
+++ b/apps/web/src/components/code-panel.tsx
@@ -2,7 +2,7 @@
 
 import { arteOdysseyAdapter } from '@decoro/adapter-arte-odyssey';
 import type { Spec } from '@json-render/core';
-import { Button, CopyIcon } from '@k8o/arte-odyssey';
+import { Button, CopyIcon, SparklesIcon } from '@k8o/arte-odyssey';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { codeToHtml } from 'shiki';
 
@@ -97,9 +97,16 @@ export const CodePanel = ({ spec }: Props) => {
 
   if (code.kind === 'empty') {
     return (
-      <div className="text-fg-subtle flex h-full flex-col items-center justify-center gap-2 px-6 text-center">
-        <p className="text-sm">
-          Generated TSX will appear here once you describe a UI.
+      <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
+        <span className="text-primary-fg" aria-hidden="true">
+          <SparklesIcon size="lg" />
+        </span>
+        <p className="text-fg-base text-base font-medium">
+          Generated TSX will appear here
+        </p>
+        <p className="text-fg-mute max-w-md text-sm">
+          Describe a screen on the left — Decoro renders it live and shows the
+          matching ArteOdyssey TSX you can copy.
         </p>
       </div>
     );

--- a/apps/web/src/components/home-shell.tsx
+++ b/apps/web/src/components/home-shell.tsx
@@ -3,9 +3,10 @@
 import { ViewIcon } from '@k8o/arte-odyssey';
 import { useState } from 'react';
 
+import type { ChatMessage } from '../lib/chat-types.ts';
 import { useDecoroChat } from '../lib/use-decoro-chat.ts';
 import { AppHeader } from './app-header.tsx';
-import { type ChatMessage, ChatPane } from './chat-pane.tsx';
+import { ChatPane } from './chat-pane.tsx';
 import { CodePanel } from './code-panel.tsx';
 import { PreviewFrame } from './preview-frame.tsx';
 import { ShareButton } from './share-button.tsx';

--- a/apps/web/src/components/home-shell.tsx
+++ b/apps/web/src/components/home-shell.tsx
@@ -1,15 +1,26 @@
 'use client';
 
-import { Heading, SparklesIcon, ViewIcon } from '@k8o/arte-odyssey';
+import { ViewIcon } from '@k8o/arte-odyssey';
 import { useState } from 'react';
 
 import { useDecoroChat } from '../lib/use-decoro-chat.ts';
+import { AppHeader } from './app-header.tsx';
 import { type ChatMessage, ChatPane } from './chat-pane.tsx';
 import { CodePanel } from './code-panel.tsx';
 import { PreviewFrame } from './preview-frame.tsx';
 import { ShareButton } from './share-button.tsx';
+import {
+  CodeBracketsIcon,
+  type TabItem,
+  TabSwitcher,
+} from './tab-switcher.tsx';
 
 type OutputTab = 'preview' | 'code';
+
+const OUTPUT_TABS: ReadonlyArray<TabItem<OutputTab>> = [
+  { id: 'preview', label: 'Preview', icon: <ViewIcon size="sm" /> },
+  { id: 'code', label: 'Code', icon: <CodeBracketsIcon /> },
+];
 
 /**
  * Top-level client shell for `/`. Wires the chat pane to `useDecoroChat`,
@@ -33,24 +44,16 @@ export const HomeShell = () => {
 
   return (
     <div className="bg-bg-surface text-fg-base flex h-dvh flex-col">
-      <header className="bg-bg-base border-border-subtle flex items-center justify-between border-b px-6 py-4">
-        <div className="flex items-center gap-3">
-          <span className="text-primary-fg" aria-hidden="true">
-            <SparklesIcon size="lg" />
-          </span>
-          <div className="flex items-baseline gap-3">
-            <Heading type="h1">Decoro</Heading>
-            <p className="text-fg-mute text-sm">
-              AI UI generation for ArteOdyssey
-            </p>
-          </div>
-        </div>
-        <ShareButton
-          spec={spec}
-          messages={chatMessages}
-          isStreaming={isStreaming}
-        />
-      </header>
+      <AppHeader
+        tagline="AI UI generation for ArteOdyssey"
+        rightSlot={
+          <ShareButton
+            spec={spec}
+            messages={chatMessages}
+            isStreaming={isStreaming}
+          />
+        }
+      />
       <main className="flex flex-1 gap-4 overflow-hidden p-4">
         <section
           aria-label="Chat"
@@ -69,7 +72,12 @@ export const HomeShell = () => {
           aria-label="Output"
           className="bg-bg-base flex w-7/12 flex-col overflow-hidden rounded-xl shadow-sm"
         >
-          <OutputTabs value={tab} onChange={setTab} />
+          <TabSwitcher
+            ariaLabel="Output"
+            tabs={OUTPUT_TABS}
+            value={tab}
+            onChange={setTab}
+          />
           <div className="relative flex-1 overflow-hidden">
             <div hidden={tab !== 'preview'} className="h-full">
               <PreviewFrame spec={spec} />
@@ -83,74 +91,3 @@ export const HomeShell = () => {
     </div>
   );
 };
-
-const OutputTabs = ({
-  value,
-  onChange,
-}: {
-  value: OutputTab;
-  onChange: (next: OutputTab) => void;
-}) => {
-  const tabs: Array<{ id: OutputTab; label: string; icon: React.ReactNode }> = [
-    { id: 'preview', label: 'Preview', icon: <ViewIcon size="sm" /> },
-    { id: 'code', label: 'Code', icon: <CodeBracketsIcon /> },
-  ];
-  return (
-    <div
-      role="tablist"
-      aria-label="Output"
-      className="border-border-subtle bg-bg-base flex gap-1 border-b px-3 pt-2"
-    >
-      {tabs.map((t) => {
-        const active = value === t.id;
-        return (
-          <button
-            key={t.id}
-            type="button"
-            role="tab"
-            aria-selected={active}
-            onClick={() => {
-              onChange(t.id);
-            }}
-            className={[
-              'relative flex cursor-pointer items-center gap-1.5 rounded-t-lg px-3 py-2 text-sm font-medium transition-colors',
-              active
-                ? 'text-primary-fg'
-                : 'text-fg-mute hover:bg-primary-bg-subtle hover:text-primary-fg',
-            ].join(' ')}
-          >
-            <span aria-hidden="true">{t.icon}</span>
-            {t.label}
-            {active ? (
-              <span
-                aria-hidden="true"
-                className="bg-primary-border absolute right-0 -bottom-px left-0 h-0.5 rounded-full"
-              />
-            ) : null}
-          </button>
-        );
-      })}
-    </div>
-  );
-};
-
-/**
- * Inline `< />` glyph used for the Code tab — ArteOdyssey's icon set doesn't
- * ship a code/braces icon, so we draw a tiny one matching `size="sm"`.
- */
-const CodeBracketsIcon = () => (
-  <svg
-    aria-hidden="true"
-    width="16"
-    height="16"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <polyline points="16 18 22 12 16 6" />
-    <polyline points="8 6 2 12 8 18" />
-  </svg>
-);

--- a/apps/web/src/components/share-button.tsx
+++ b/apps/web/src/components/share-button.tsx
@@ -4,7 +4,7 @@ import type { Spec } from '@json-render/core';
 import { Button, LinkIcon } from '@k8o/arte-odyssey';
 import { useEffect, useState } from 'react';
 
-import type { ChatMessage } from './chat-pane.tsx';
+import type { ChatMessage } from '../lib/chat-types.ts';
 
 type Props = {
   spec: Spec | null;

--- a/apps/web/src/components/share-view.tsx
+++ b/apps/web/src/components/share-view.tsx
@@ -1,12 +1,18 @@
 'use client';
 
-import type { Spec } from '@json-render/core';
-import { Anchor, Heading, SparklesIcon, ViewIcon } from '@k8o/arte-odyssey';
+import { Anchor, SparklesIcon, ViewIcon } from '@k8o/arte-odyssey';
 import { useEffect, useState } from 'react';
 
 import type { SnapshotRecord } from '../lib/share-types.ts';
+import { toSpec } from '../lib/spec-schema.ts';
+import { AppHeader } from './app-header.tsx';
 import { CodePanel } from './code-panel.tsx';
 import { PreviewFrame } from './preview-frame.tsx';
+import {
+  CodeBracketsIcon,
+  type TabItem,
+  TabSwitcher,
+} from './tab-switcher.tsx';
 
 type Props = {
   snapshot: SnapshotRecord;
@@ -14,20 +20,18 @@ type Props = {
 
 type OutputTab = 'preview' | 'code';
 
+const OUTPUT_TABS: ReadonlyArray<TabItem<OutputTab>> = [
+  { id: 'preview', label: 'Preview', icon: <ViewIcon size="sm" /> },
+  { id: 'code', label: 'Code', icon: <CodeBracketsIcon /> },
+];
+
 /**
  * Read-only renderer for `/share/[id]`. Mirrors the home shell's two-pane
  * layout but drops the prompt input — viewers cannot iterate on a snapshot.
- *
- * Tabs are rolled by hand for the same reason as `home-shell` (keep the
- * preview iframe mounted across tab switches so its postMessage handshake
- * survives).
  */
 export const ShareView = ({ snapshot }: Props) => {
   const [tab, setTab] = useState<OutputTab>('preview');
-  // Zod infers `visible` as `unknown`; the Spec contract narrows it to
-  // VisibilityCondition. The /api/generate route does the same cast — see
-  // its `augmentLastUserMessage` callsite.
-  const spec = snapshot.spec as unknown as Spec;
+  const spec = toSpec(snapshot.spec);
   // Format the captured-at stamp on the client only. `toLocaleString()`
   // depends on the runtime's locale + timezone; running it during SSR and
   // again on hydration produces a mismatch warning whenever the recipient's
@@ -42,18 +46,10 @@ export const ShareView = ({ snapshot }: Props) => {
 
   return (
     <div className="bg-bg-surface text-fg-base flex h-dvh flex-col">
-      <header className="bg-bg-base border-border-subtle flex items-center justify-between border-b px-6 py-4">
-        <div className="flex items-center gap-3">
-          <span className="text-primary-fg" aria-hidden="true">
-            <SparklesIcon size="lg" />
-          </span>
-          <div className="flex items-baseline gap-3">
-            <Heading type="h1">Decoro</Heading>
-            <p className="text-fg-mute text-sm">Shared snapshot · read-only</p>
-          </div>
-        </div>
-        <Anchor href="/">Open Decoro →</Anchor>
-      </header>
+      <AppHeader
+        tagline="Shared snapshot · read-only"
+        rightSlot={<Anchor href="/">Open Decoro →</Anchor>}
+      />
       <main className="flex flex-1 gap-4 overflow-hidden p-4">
         <section
           aria-label="Conversation"
@@ -96,7 +92,12 @@ export const ShareView = ({ snapshot }: Props) => {
           aria-label="Output"
           className="bg-bg-base flex w-7/12 flex-col overflow-hidden rounded-xl shadow-sm"
         >
-          <ShareTabs value={tab} onChange={setTab} />
+          <TabSwitcher
+            ariaLabel="Output"
+            tabs={OUTPUT_TABS}
+            value={tab}
+            onChange={setTab}
+          />
           <div className="relative flex-1 overflow-hidden">
             <div hidden={tab !== 'preview'} className="h-full">
               <PreviewFrame spec={spec} />
@@ -110,70 +111,3 @@ export const ShareView = ({ snapshot }: Props) => {
     </div>
   );
 };
-
-const ShareTabs = ({
-  value,
-  onChange,
-}: {
-  value: OutputTab;
-  onChange: (next: OutputTab) => void;
-}) => {
-  const tabs: Array<{ id: OutputTab; label: string; icon: React.ReactNode }> = [
-    { id: 'preview', label: 'Preview', icon: <ViewIcon size="sm" /> },
-    { id: 'code', label: 'Code', icon: <CodeBracketsIcon /> },
-  ];
-  return (
-    <div
-      role="tablist"
-      aria-label="Output"
-      className="border-border-subtle bg-bg-base flex gap-1 border-b px-3 pt-2"
-    >
-      {tabs.map((t) => {
-        const active = value === t.id;
-        return (
-          <button
-            key={t.id}
-            type="button"
-            role="tab"
-            aria-selected={active}
-            onClick={() => {
-              onChange(t.id);
-            }}
-            className={[
-              'relative flex cursor-pointer items-center gap-1.5 rounded-t-lg px-3 py-2 text-sm font-medium transition-colors',
-              active
-                ? 'text-primary-fg'
-                : 'text-fg-mute hover:bg-primary-bg-subtle hover:text-primary-fg',
-            ].join(' ')}
-          >
-            <span aria-hidden="true">{t.icon}</span>
-            {t.label}
-            {active ? (
-              <span
-                aria-hidden="true"
-                className="bg-primary-border absolute right-0 -bottom-px left-0 h-0.5 rounded-full"
-              />
-            ) : null}
-          </button>
-        );
-      })}
-    </div>
-  );
-};
-
-const CodeBracketsIcon = () => (
-  <svg
-    aria-hidden="true"
-    width="16"
-    height="16"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <polyline points="16 18 22 12 16 6" />
-    <polyline points="8 6 2 12 8 18" />
-  </svg>
-);

--- a/apps/web/src/components/tab-switcher.tsx
+++ b/apps/web/src/components/tab-switcher.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+/**
+ * Generic tab switcher matching ArteOdyssey's `Tabs` look (teal underline on
+ * active, hover bg). Rolled by hand instead of using `Tabs.Root` because the
+ * published `Tabs.Panel` returns `null` for the inactive tab — we need both
+ * panels to stay mounted so the preview iframe's postMessage handshake
+ * survives tab changes (see HomeShell + ShareView callers).
+ */
+export type TabItem<T extends string> = {
+  id: T;
+  label: string;
+  icon: ReactNode;
+};
+
+type Props<T extends string> = {
+  ariaLabel: string;
+  tabs: ReadonlyArray<TabItem<T>>;
+  value: T;
+  onChange: (next: T) => void;
+};
+
+export const TabSwitcher = <T extends string>({
+  ariaLabel,
+  tabs,
+  value,
+  onChange,
+}: Props<T>) => (
+  <div
+    role="tablist"
+    aria-label={ariaLabel}
+    className="border-border-subtle bg-bg-base flex gap-1 border-b px-3 pt-2"
+  >
+    {tabs.map((t) => {
+      const active = value === t.id;
+      return (
+        <button
+          key={t.id}
+          type="button"
+          role="tab"
+          aria-selected={active}
+          onClick={() => {
+            onChange(t.id);
+          }}
+          className={[
+            'relative flex cursor-pointer items-center gap-1.5 rounded-t-lg px-3 py-2 text-sm font-medium transition-colors',
+            active
+              ? 'text-primary-fg'
+              : 'text-fg-mute hover:bg-primary-bg-subtle hover:text-primary-fg',
+          ].join(' ')}
+        >
+          <span aria-hidden="true">{t.icon}</span>
+          {t.label}
+          {active ? (
+            <span
+              aria-hidden="true"
+              className="bg-primary-border absolute right-0 -bottom-px left-0 h-0.5 rounded-full"
+            />
+          ) : null}
+        </button>
+      );
+    })}
+  </div>
+);
+
+/**
+ * `< />` glyph for the Code tab. ArteOdyssey's icon set doesn't ship a
+ * code/braces icon today; matches `size="sm"` (16px) to align with
+ * ArteOdyssey icons in the same row.
+ */
+export const CodeBracketsIcon = () => (
+  <svg
+    aria-hidden="true"
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <polyline points="16 18 22 12 16 6" />
+    <polyline points="8 6 2 12 8 18" />
+  </svg>
+);

--- a/apps/web/src/lib/api-response.ts
+++ b/apps/web/src/lib/api-response.ts
@@ -1,0 +1,10 @@
+/**
+ * Standard JSON error response shape used across all `/api/*` routes.
+ * Picked for consistency with the existing client expectations
+ * (`useDecoroChat` already reads `data.message ?? data.error`).
+ */
+export const jsonError = (status: number, message: string): Response =>
+  new Response(JSON.stringify({ message }), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });

--- a/apps/web/src/lib/chat-types.ts
+++ b/apps/web/src/lib/chat-types.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+import { MAX_MESSAGE_CHARS } from './spec-schema.ts';
+
+/**
+ * Single in-flight chat message shape — the canonical chat primitive.
+ *
+ * Used by:
+ * - `useDecoroChat` (in-process React state)
+ * - `<ChatPane>` (UI rendering)
+ * - `<ShareView>` (read-only transcript)
+ * - `snapshotInputSchema` (POST /api/share validates against this exact
+ *   shape via `chatMessageSchema`)
+ *
+ * The schema and the type live next to each other so `z.infer` keeps the
+ * validator and the in-process type in lockstep — they cannot drift.
+ */
+export const chatMessageSchema = z.object({
+  id: z.string().min(1).max(64),
+  role: z.enum(['user', 'assistant']),
+  text: z.string().max(MAX_MESSAGE_CHARS),
+});
+
+export type ChatMessage = z.infer<typeof chatMessageSchema>;

--- a/apps/web/src/lib/share-types.ts
+++ b/apps/web/src/lib/share-types.ts
@@ -1,14 +1,14 @@
 import { z } from 'zod';
 
-import { MAX_MESSAGE_CHARS, MAX_MESSAGES, specSchema } from './spec-schema.ts';
+import { chatMessageSchema } from './chat-types.ts';
+import { MAX_MESSAGES, specSchema } from './spec-schema.ts';
 
 /**
- * Shared Zod schemas + types for share snapshots (see ADR-013, Tier 2).
+ * Zod schemas + types for share snapshots (see ADR-013, Tier 2).
  *
- * The `spec` validator is shared with `/api/generate`; the message shape
- * differs (the share snapshot carries the full chat-pane shape `{id, role,
- * text}` rather than the LLM API's `{role, content}`), so the message
- * schema lives here.
+ * Builds on the canonical chat / spec primitives: `chatMessageSchema` from
+ * chat-types.ts and `specSchema` from spec-schema.ts. Share-specific shape
+ * (id + createdAt + schemaVersion + messages array + spec) lives here.
  *
  * Stored snapshots are validated on both ingest (POST) and read (GET) — read
  * validation is defense-in-depth in case the on-disk file is tampered with
@@ -34,12 +34,6 @@ export const newShareId = (): string => {
     .replaceAll('=', '');
 };
 
-const chatMessageSchema = z.object({
-  id: z.string().min(1).max(64),
-  role: z.enum(['user', 'assistant']),
-  text: z.string().max(MAX_MESSAGE_CHARS),
-});
-
 export const snapshotInputSchema = z.object({
   messages: z.array(chatMessageSchema).min(1).max(MAX_MESSAGES),
   spec: specSchema,
@@ -53,14 +47,3 @@ export const snapshotRecordSchema = snapshotInputSchema.extend({
 
 export type SnapshotInput = z.infer<typeof snapshotInputSchema>;
 export type SnapshotRecord = z.infer<typeof snapshotRecordSchema>;
-/**
- * The single in-flight chat message shape. Used by:
- * - `useDecoroChat` (in-process)
- * - `<ChatPane>` (UI)
- * - `<ShareView>` (read-only transcript)
- * - snapshot bodies (POST/GET to /api/share, validated by `chatMessageSchema`)
- *
- * Kept here so the schema and the type stay in lockstep — `z.infer` would
- * disagree with a hand-written type if the schema drifts.
- */
-export type ChatMessage = z.infer<typeof chatMessageSchema>;

--- a/apps/web/src/lib/share-types.ts
+++ b/apps/web/src/lib/share-types.ts
@@ -1,21 +1,19 @@
-import type { Spec } from '@json-render/core';
 import { z } from 'zod';
+
+import { MAX_MESSAGE_CHARS, MAX_MESSAGES, specSchema } from './spec-schema.ts';
 
 /**
  * Shared Zod schemas + types for share snapshots (see ADR-013, Tier 2).
  *
- * The schemas mirror the limits applied at `/api/generate` so a snapshot
- * cannot smuggle in payloads larger than the generator itself accepts.
+ * The `spec` validator is shared with `/api/generate`; the message shape
+ * differs (the share snapshot carries the full chat-pane shape `{id, role,
+ * text}` rather than the LLM API's `{role, content}`), so the message
+ * schema lives here.
+ *
  * Stored snapshots are validated on both ingest (POST) and read (GET) — read
  * validation is defense-in-depth in case the on-disk file is tampered with
  * outside the API.
  */
-
-const MAX_MESSAGES = 50;
-const MAX_MESSAGE_CHARS = 4000;
-const MAX_SPEC_ELEMENTS = 200;
-const MAX_ELEMENT_CHILDREN = 50;
-const MAX_COMPONENT_TYPE_CHARS = 50;
 
 export const SHARE_ID_PATTERN = /^[A-Za-z0-9_-]{12}$/;
 
@@ -36,32 +34,14 @@ export const newShareId = (): string => {
     .replaceAll('=', '');
 };
 
-const messageSchema = z.object({
+const chatMessageSchema = z.object({
   id: z.string().min(1).max(64),
   role: z.enum(['user', 'assistant']),
   text: z.string().max(MAX_MESSAGE_CHARS),
 });
 
-const elementSchema = z.object({
-  type: z.string().min(1).max(MAX_COMPONENT_TYPE_CHARS),
-  props: z.record(z.string(), z.unknown()),
-  children: z.array(z.string()).max(MAX_ELEMENT_CHILDREN),
-  visible: z.unknown().optional(),
-});
-
-const specSchema = z.object({
-  root: z.string(),
-  elements: z
-    .record(z.string(), elementSchema)
-    .refine(
-      (e) => Object.keys(e).length <= MAX_SPEC_ELEMENTS,
-      `spec exceeds max ${MAX_SPEC_ELEMENTS.toString()} elements`,
-    ),
-  state: z.unknown().optional(),
-});
-
 export const snapshotInputSchema = z.object({
-  messages: z.array(messageSchema).min(1).max(MAX_MESSAGES),
+  messages: z.array(chatMessageSchema).min(1).max(MAX_MESSAGES),
   spec: specSchema,
 });
 
@@ -73,5 +53,14 @@ export const snapshotRecordSchema = snapshotInputSchema.extend({
 
 export type SnapshotInput = z.infer<typeof snapshotInputSchema>;
 export type SnapshotRecord = z.infer<typeof snapshotRecordSchema>;
-export type SharedMessage = z.infer<typeof messageSchema>;
-export type SharedSpec = Spec;
+/**
+ * The single in-flight chat message shape. Used by:
+ * - `useDecoroChat` (in-process)
+ * - `<ChatPane>` (UI)
+ * - `<ShareView>` (read-only transcript)
+ * - snapshot bodies (POST/GET to /api/share, validated by `chatMessageSchema`)
+ *
+ * Kept here so the schema and the type stay in lockstep — `z.infer` would
+ * disagree with a hand-written type if the schema drifts.
+ */
+export type ChatMessage = z.infer<typeof chatMessageSchema>;

--- a/apps/web/src/lib/spec-schema.ts
+++ b/apps/web/src/lib/spec-schema.ts
@@ -1,0 +1,46 @@
+import type { Spec } from '@json-render/core';
+import { z } from 'zod';
+
+/**
+ * Single source of truth for the spec / element / message limits enforced
+ * at every API boundary that accepts user-controlled JSON. Both
+ * `/api/generate` (request body) and `/api/share` (snapshot body) reuse
+ * these so the limits stay in lockstep.
+ *
+ * Sized for "self-hosted, trusted-network MVP": generous enough that real
+ * sessions never bump them, tight enough that a runaway client or hostile
+ * insider cannot DoS the endpoint or rack up an unbounded LLM bill.
+ */
+export const MAX_MESSAGES = 50;
+export const MAX_MESSAGE_CHARS = 4000;
+export const MAX_SPEC_ELEMENTS = 200;
+export const MAX_ELEMENT_CHILDREN = 50;
+export const MAX_COMPONENT_TYPE_CHARS = 50;
+
+export const elementSchema = z.object({
+  type: z.string().min(1).max(MAX_COMPONENT_TYPE_CHARS),
+  props: z.record(z.string(), z.unknown()),
+  children: z.array(z.string()).max(MAX_ELEMENT_CHILDREN),
+  visible: z.unknown().optional(),
+});
+
+export const specSchema = z.object({
+  root: z.string(),
+  elements: z
+    .record(z.string(), elementSchema)
+    .refine(
+      (e) => Object.keys(e).length <= MAX_SPEC_ELEMENTS,
+      `spec exceeds max ${MAX_SPEC_ELEMENTS.toString()} elements`,
+    ),
+  state: z.unknown().optional(),
+});
+
+/**
+ * Zod's inferred element type widens `visible` to `unknown`; the json-render
+ * `Spec` contract narrows it to `VisibilityCondition`. The shape is
+ * structurally compatible — anything our schema accepts is a valid Spec —
+ * so this cast is the documented escape hatch. Centralized here so the
+ * `as unknown as` pattern doesn't get sprinkled across callers.
+ */
+export const toSpec = (parsed: z.infer<typeof specSchema>): Spec =>
+  parsed as unknown as Spec;


### PR DESCRIPTION
## Summary

Two PRs of feature work (#28 redesign, #29 share Tier 2) accumulated several almost-identical chunks across `HomeShell` + `ShareView` + the two `/api` routes. This pass extracts the obvious wins; deliberately stops short of a generic `<AppShell>` since there are still only two callers.

## What's extracted

| New module | Replaces | Notes |
|---|---|---|
| `components/tab-switcher.tsx` | `OutputTabs` in HomeShell + `ShareTabs` in ShareView, plus the duplicated `<CodeBracketsIcon>` SVG | Generic `<TabSwitcher<T extends string>>` keeps the same teal-underline behavior. Both callers were rolling this by hand to keep the iframe mounted across switches |
| `components/app-header.tsx` | Header `<header>` chunk (SparklesIcon + Decoro + tagline) duplicated in both pages | `tagline` and `rightSlot` props vary per page (`<ShareButton>` on /, `<Anchor>Open Decoro →</Anchor>` on /share/[id]) |
| `lib/spec-schema.ts` | Side-by-side `MAX_*` constants + `elementSchema` + `specSchema` in `/api/generate` and `share-types.ts` | Single source of truth for the validation limits both API boundaries enforce. Includes `toSpec(parsed)` so the Zod-inferred-element-vs-`Spec` cast lives in one place rather than scattered as `as unknown as Spec` |
| `lib/api-response.ts` | `jsonError(status, message)` helper duplicated in both `/api` routes | Shared response helper |

## Inlined consolidations

- **`ChatMessage` type** now lives with the schema in `share-types.ts` (derived from the same `chatMessageSchema` via `z.infer`) so the validator and the in-process type can't drift. `chat-pane.tsx` re-exports it for callers that already imported from there.
- **`code-panel.tsx` empty state** matches the preview empty state visually (centered `<SparklesIcon size="lg">` + headline + helper) instead of the lone-line fallback it had before.

## Net delta

- Existing 8 files: **-173 lines**
- New 4 modules: **+172 lines**

Roughly the same total LoC but the **structure / drift surface is dramatically smaller**. Two API routes can no longer have their `MAX_MESSAGES` slip out of sync; the tab UI and brand chrome each have one definition.

## What this PR deliberately does NOT do

| Considered | Why deferred |
|---|---|
| Unified `<AppShell>` abstraction | Two callers is too few; the layout difference between Home (chat input) and Share (read-only transcript) would force prop bloat |
| Storage adapter abstraction (`filesystem` \| `vercel-kv` \| `sqlite`) | Wait until Vercel deploy actually motivates it. ADR-013 already calls this out as the natural extension point |
| Tests for share-store / share routes / useDecoroChat | Aligned with current MVP scope (only adapter-arte-odyssey has tests). Worth flagging as future work |

## Test plan

- [x] `pnpm typecheck` (4 packages, all pass)
- [x] `pnpm test` (15 / 15)
- [x] `pnpm check` (58 files formatted, 41 lint-clean)
- [x] Manual: home shell loads, example chips fill prompt, send streams, both tabs render, Share button copies URL
- [x] Manual: `/share/[id]` loads correctly with `toSpec` cast (no console hydration errors)
- [x] Manual: `curl POST /api/share` still returns `{id, url}`; `GET /api/share/[id]` still returns the snapshot
- [x] Visual regression: home empty / code-panel empty (new SparklesIcon style) / home active — captured locally, identical to pre-refactor except the upgraded code-panel empty state

## Risk

Low — pure refactoring with comprehensive type / lint / test coverage. The largest behavior change is `code-panel.tsx`'s empty-state visual upgrade; the rest is structural moves that the type checker fully validates.