### PR TITLE
fix(codegen): strip schema-incompatible props (className on Card et al.)

### DIFF
--- a/apps/web/decoro.config.ts
+++ b/apps/web/decoro.config.ts
@@ -2,23 +2,19 @@ import { arteOdysseyAdapter } from '@decoro/adapter-arte-odyssey';
 import type { LlmConfig } from '@decoro/llm-config';
 
 /**
- * Decoro configuration. Edit this file to point Decoro at your preferred LLM
- * provider and model. API keys are read from environment variables (see
- * `.env.example` at the repo root); do not hard-code them here.
+ * Decoro configuration. Edit this file to point Decoro at your preferred
+ * LLM provider and design-system adapter. API keys are read from
+ * environment variables — set them in `apps/web/.env.local` (see
+ * `.env.example`), do not hard-code them here.
  *
- * Lives next to the Next.js app (rather than the repo root that
- * `docs/architecture.md` originally sketched) for two practical reasons:
- *   1. pnpm does not hoist workspace packages to the repo root, so a config at
- *      the repo root cannot resolve `@decoro/llm-config`.
- *   2. Next.js picks up `apps/web/.env.local` for the API key without extra
- *      wiring when this file is consumed from `apps/web` server code.
+ * Decoro is most thoroughly tested on Anthropic Claude. The other
+ * provider options are wired so you can run Decoro against whatever
+ * account / billing you already have.
  *
- * Switching providers is a one-line change. The library design hypothesis
- * (ADR-003) is verified primarily on Anthropic Claude — the other branches
- * are wired so contributors can smoke-test without an Anthropic key.
+ * Switching providers is a one-line change to `llm` below.
  *
- * Vercel AI Gateway (default — free monthly credit, one key reaches every
- * provider, lowest setup friction):
+ * Vercel AI Gateway (recommended — one key reaches Anthropic / Google /
+ * OpenAI; Vercel's free tier covers light dogfood):
  *   { provider: 'gateway', model: 'anthropic/claude-sonnet-4-6',
  *     apiKey: process.env['AI_GATEWAY_API_KEY'] }
  *
@@ -26,29 +22,29 @@ import type { LlmConfig } from '@decoro/llm-config';
  *   { provider: 'anthropic', model: 'claude-sonnet-4-6',
  *     apiKey: process.env['ANTHROPIC_API_KEY'] }
  *
- * Google Gemini direct (free tier):
+ * Google Gemini direct (free tier available):
  *   { provider: 'google', model: 'gemini-2.5-flash',
  *     apiKey: process.env['GOOGLE_GENERATIVE_AI_API_KEY'] }
  *
- * Local Claude CLI (subscription-backed monkey testing — no API key):
+ * Local Claude CLI (uses your personal Claude.ai subscription instead of
+ * an API key — for solo local dogfood only):
  *   { provider: 'subprocess-claude', model: 'sonnet' }
- * Spawns the locally installed `claude` binary per request and adapts its
- * `--print --output-format stream-json` output. Uses whatever account
- * `claude` is logged into. Process spawn adds ~1.5s/turn so this is for
- * manual dogfood only — keep an API-backed provider for tests / CI.
+ * Run `claude setup-token` once and put `CLAUDE_CODE_OAUTH_TOKEN` in
+ * `.env.local`. Each request spawns the `claude` binary (~1.5s overhead),
+ * so this is for manual exploration only — tests / CI should use an
+ * API-backed provider.
  *
- * IMPORTANT — subscription terms: this provider consumes the operator's
- * personal Claude.ai subscription quota (5-hour rate limit). It is OK to
- * use locally for self-driven dogfood, but DO NOT ship a deployment
- * pointed at this provider — exposing your subscription as a backend for
- * other users would violate Anthropic's ToS (effectively reselling
- * Claude). Production / multi-user deployments must use an API-backed
- * provider (`gateway`, `anthropic`, `google`).
+ * IMPORTANT: `subprocess-claude` consumes the operator's personal
+ * subscription quota (5-hour rate limit) and must NEVER be used in a
+ * deployment that other people can reach. Exposing your subscription as
+ * a backend for other users violates Anthropic's terms of service
+ * (effectively reselling Claude). Production / multi-user deployments
+ * must use an API-backed provider (`gateway`, `anthropic`, `google`).
  *
- * Adapter selection lives elsewhere for now — apps/web pins
- * `@decoro/adapter-arte-odyssey` directly. A `defineConfig` helper that
- * bundles adapter + LLM together can ship once we have a second adapter to
- * motivate the abstraction (per ADR-004).
+ * Why this file lives under `apps/web/` instead of the repo root:
+ * pnpm doesn't hoist workspace packages to the root, so a root-level
+ * config can't resolve `@decoro/llm-config`. Keeping it next to the
+ * Next.js app also lets it pick up `apps/web/.env.local` automatically.
  */
 export const llm: LlmConfig = {
   provider: 'subprocess-claude',
@@ -56,31 +52,30 @@ export const llm: LlmConfig = {
 };
 
 /**
- * Adapter binding. Pinned here so the rest of `apps/web` consumes the
- * adapter through the abstract `Adapter` contract — `code-panel.tsx`,
- * `preview/page.tsx`, and `/api/generate` all import this rather than
- * `@decoro/adapter-arte-odyssey` directly. Switching to a future
- * `@decoro/adapter-mui` etc. is a one-line change here, no consumer churn.
- *
- * Per ADR-004 we deliberately do not introduce a `defineConfig({ adapter,
- * llm })` wrapper — there's only one adapter today and one config field
- * pattern is enough for both bindings.
+ * Design-system adapter binding. The rest of `apps/web` imports `adapter`
+ * from this file rather than `@decoro/adapter-arte-odyssey` directly, so
+ * pointing Decoro at a different design system is a one-line change here:
+ * write your own `@your-org/adapter-<name>` implementing the `Adapter`
+ * contract from `@decoro/adapter-spec`, then swap the import / export
+ * below. No other code in `apps/web` needs to change.
  */
 // Typed as `typeof arteOdysseyAdapter` (not the bare `Adapter` interface)
 // so the registry's component type stays narrow — `Adapter` defaults
-// `TComponent` to `unknown`, which json-render's `ComponentRegistry` would
-// then refuse. Concrete adapter exports preserve the right specialization.
+// `TComponent` to `unknown`, which json-render's `ComponentRegistry`
+// would then refuse. Concrete adapter exports preserve the right
+// specialization.
 export const adapter = arteOdysseyAdapter;
 
 /**
- * Share-snapshot configuration (see ADR-013).
+ * Share-snapshot configuration.
  *
- * `publicBaseUrl` is the absolute origin Decoro should use when handing out
- * shareable URLs (e.g. `https://decoro.example.com`). When unset, the share
- * route falls back to `X-Forwarded-Proto` + `X-Forwarded-Host` (or `Host`)
- * — fine for plain `pnpm dev` and most reverse-proxy setups, but if your
- * proxy strips those headers the URL handed back to clients won't be
- * reachable from outside the box. Set this explicitly in that case.
+ * `publicBaseUrl` is the absolute origin Decoro uses when generating
+ * shareable URLs (e.g. `https://decoro.example.com`). Leave unset for
+ * local dev — the share route then falls back to the request's
+ * `X-Forwarded-Proto` + `X-Forwarded-Host` (or `Host`) headers, which
+ * works for `pnpm dev` and most reverse-proxy setups. Set this
+ * explicitly only if your proxy strips those headers, otherwise the
+ * shared URL handed back to clients won't be reachable from outside.
  *
  * No trailing slash.
  */

--- a/apps/web/decoro.config.ts
+++ b/apps/web/decoro.config.ts
@@ -36,9 +36,9 @@ import type { LlmConfig } from '@decoro/llm-config';
  * motivate the abstraction (per ADR-004).
  */
 export const llm: LlmConfig = {
-  provider: 'google',
-  model: 'gemini-2.5-flash',
-  apiKey: process.env['GOOGLE_GENERATIVE_AI_API_KEY'],
+  provider: 'gateway',
+  model: 'anthropic/claude-sonnet-4-6',
+  apiKey: process.env['AI_GATEWAY_API_KEY'],
 };
 
 /**

--- a/apps/web/decoro.config.ts
+++ b/apps/web/decoro.config.ts
@@ -30,15 +30,29 @@ import type { LlmConfig } from '@decoro/llm-config';
  *   { provider: 'google', model: 'gemini-2.5-flash',
  *     apiKey: process.env['GOOGLE_GENERATIVE_AI_API_KEY'] }
  *
+ * Local Claude CLI (subscription-backed monkey testing — no API key):
+ *   { provider: 'subprocess-claude', model: 'sonnet' }
+ * Spawns the locally installed `claude` binary per request and adapts its
+ * `--print --output-format stream-json` output. Uses whatever account
+ * `claude` is logged into. Process spawn adds ~1.5s/turn so this is for
+ * manual dogfood only — keep an API-backed provider for tests / CI.
+ *
+ * IMPORTANT — subscription terms: this provider consumes the operator's
+ * personal Claude.ai subscription quota (5-hour rate limit). It is OK to
+ * use locally for self-driven dogfood, but DO NOT ship a deployment
+ * pointed at this provider — exposing your subscription as a backend for
+ * other users would violate Anthropic's ToS (effectively reselling
+ * Claude). Production / multi-user deployments must use an API-backed
+ * provider (`gateway`, `anthropic`, `google`).
+ *
  * Adapter selection lives elsewhere for now — apps/web pins
  * `@decoro/adapter-arte-odyssey` directly. A `defineConfig` helper that
  * bundles adapter + LLM together can ship once we have a second adapter to
  * motivate the abstraction (per ADR-004).
  */
 export const llm: LlmConfig = {
-  provider: 'gateway',
-  model: 'anthropic/claude-sonnet-4-6',
-  apiKey: process.env['AI_GATEWAY_API_KEY'],
+  provider: 'subprocess-claude',
+  model: 'sonnet',
 };
 
 /**

--- a/apps/web/src/app/api/generate/route.ts
+++ b/apps/web/src/app/api/generate/route.ts
@@ -38,11 +38,26 @@ const responsePreambleInstruction = [
   '- Do not emit any prose between or after the patches.',
 ].join('\n');
 
+// ArteOdyssey components do not accept `className` (the design system
+// chooses styling internally). Only the layout HTML elements (div, section,
+// header, main) accept className, and only from the curated allowlist
+// declared in their schema. Codegen also strips unknown props as
+// belt-and-braces, but reminding the model up front is cheaper than
+// repairing the spec downstream.
+const propsDisciplineInstruction = [
+  'Prop discipline:',
+  '- Set only the props each component declares in its catalog entry.',
+  '- Do NOT add `className` to ArteOdyssey components (Button, Card, FormControl, TextField, etc.). They control their own styling.',
+  '- `className` is allowed ONLY on layout HTML elements (div, section, header, main), and only with the allowlisted utility tokens shown in their schema.',
+].join('\n');
+
 const systemPrompt = [
   adapter.catalog.prompt({ mode: 'standalone' }),
   '',
   'Library design principles:',
   adapter.metadata.designPrinciples,
+  '',
+  propsDisciplineInstruction,
   '',
   responsePreambleInstruction,
 ].join('\n');

--- a/apps/web/src/app/api/generate/route.ts
+++ b/apps/web/src/app/api/generate/route.ts
@@ -32,10 +32,14 @@ const requestSchema = z.object({
 // `createMixedStreamParser` already distinguishes JSONL patch lines from
 // prose, so the extra line lands in `onText` without disturbing patches.
 const responsePreambleInstruction = [
-  'Response format:',
-  '- First, output exactly ONE short sentence (≤ 15 words) describing what you are building or changing in this turn. Plain prose, no JSON. End with a newline.',
-  '- Then emit the JSONL patch lines as instructed above.',
-  '- Do not emit any prose between or after the patches.',
+  'Response format (STRICT — the chat UI parses prose vs JSON by line):',
+  '- Line 1: exactly ONE short sentence (≤ 15 words) describing what you are building or changing in this turn. Plain prose, no JSON, no leading whitespace.',
+  '- Line 1 MUST end with a literal newline character before any JSON appears. Do not place JSON on the same line as the sentence.',
+  '- Lines 2+: JSONL patch lines, one complete JSON object per line. No prose between or after the patches.',
+  '- Example shape:',
+  '    Adding a primary submit button.\\n',
+  '    {"op":"add","path":"/elements/btn","value":{"type":"Button","props":{"label":"Save"},"children":[]}}\\n',
+  '    {"op":"replace","path":"/root","value":"btn"}\\n',
 ].join('\n');
 
 // ArteOdyssey components do not accept `className` (the design system
@@ -51,6 +55,24 @@ const propsDisciplineInstruction = [
   '- `className` is allowed ONLY on layout HTML elements (div, section, header, main), and only with the allowlisted utility tokens shown in their schema.',
 ].join('\n');
 
+// Decoro is a design tool — users want to *see* their UI, not run it. The
+// LLM's first instinct is to produce a state-bound interactive prototype
+// (e.g. a chat with `$bindEach: '/messages'` over the message list, or
+// `$cond` for sender-side bubble styling). With state empty, the preview
+// renders nothing — the user complains "the UI hasn't changed", because
+// it literally hasn't: the template is correct, the data is missing.
+//
+// Default to mockup-first generation. The user can opt into interactive
+// behavior by asking explicitly.
+const mockupFirstInstruction = [
+  'Mockup-first generation:',
+  '- Decoro is a design tool. Users want to SEE the UI populated, not wire up state.',
+  '- Prefer STATIC content baked directly into the spec. Render 2–4 example items inline for chat / list / table / feed UIs so the preview is populated the moment generation finishes.',
+  '- AVOID `$bindEach`, `$bindState`, `$cond`, `$item`, and action bindings (`pushState`, etc.) by default. They produce templates that render empty without state initialization.',
+  '- For form UIs, leave inputs empty (the user fills them); for display UIs, show concrete example values directly in `props`.',
+  '- Only use state bindings / actions when the user EXPLICITLY asks for an interactive prototype.',
+].join('\n');
+
 const systemPrompt = [
   adapter.catalog.prompt({ mode: 'standalone' }),
   '',
@@ -58,6 +80,8 @@ const systemPrompt = [
   adapter.metadata.designPrinciples,
   '',
   propsDisciplineInstruction,
+  '',
+  mockupFirstInstruction,
   '',
   responsePreambleInstruction,
 ].join('\n');

--- a/apps/web/src/app/api/generate/route.ts
+++ b/apps/web/src/app/api/generate/route.ts
@@ -55,6 +55,19 @@ const propsDisciplineInstruction = [
   '- `className` is allowed ONLY on layout HTML elements (div, section, header, main), and only with the allowlisted utility tokens shown in their schema.',
 ].join('\n');
 
+// Icons matter — chatbot / dashboard / nav UIs lean heavily on them and the
+// LLM defaults to Material Symbols / Heroicons names because that's the
+// dominant training data. Those names do not resolve in ArteOdyssey and
+// render as raw text in the preview. The `Icon` catalog entry already
+// constrains `name` to a Zod enum of valid ArteOdyssey icons; this
+// instruction makes the constraint visible up front.
+const iconUsageInstruction = [
+  'Icons:',
+  '- Use the `Icon` component with its `name` prop set to one of the names in the catalog enum (e.g. `<Icon name="HistoryIcon" />`).',
+  '- For icon-only actions, use `IconButton` with one `Icon` child: `<IconButton label="History"><Icon name="HistoryIcon" /></IconButton>`.',
+  '- NEVER invent icon names from Material Symbols / Heroicons / Font Awesome (`help_outline`, `menu_book`, `support_agent`, etc.) — they will not resolve and will render as raw text.',
+].join('\n');
+
 // Decoro is a design tool — users want to *see* their UI, not run it. The
 // LLM's first instinct is to produce a state-bound interactive prototype
 // (e.g. a chat with `$bindEach: '/messages'` over the message list, or
@@ -80,6 +93,8 @@ const systemPrompt = [
   adapter.metadata.designPrinciples,
   '',
   propsDisciplineInstruction,
+  '',
+  iconUsageInstruction,
   '',
   mockupFirstInstruction,
   '',

--- a/apps/web/src/app/api/generate/route.ts
+++ b/apps/web/src/app/api/generate/route.ts
@@ -42,42 +42,17 @@ const responsePreambleInstruction = [
   '    {"op":"replace","path":"/root","value":"btn"}\\n',
 ].join('\n');
 
-// ArteOdyssey components do not accept `className` (the design system
-// chooses styling internally). Only the layout HTML elements (div, section,
-// header, main) accept className, and only from the curated allowlist
-// declared in their schema. Codegen also strips unknown props as
-// belt-and-braces, but reminding the model up front is cheaper than
-// repairing the spec downstream.
-const propsDisciplineInstruction = [
-  'Prop discipline:',
-  '- Set only the props each component declares in its catalog entry.',
-  '- Do NOT add `className` to ArteOdyssey components (Button, Card, FormControl, TextField, etc.). They control their own styling.',
-  '- `className` is allowed ONLY on layout HTML elements (div, section, header, main), and only with the allowlisted utility tokens shown in their schema.',
-].join('\n');
-
-// Icons matter — chatbot / dashboard / nav UIs lean heavily on them and the
-// LLM defaults to Material Symbols / Heroicons names because that's the
-// dominant training data. Those names do not resolve in ArteOdyssey and
-// render as raw text in the preview. The `Icon` catalog entry already
-// constrains `name` to a Zod enum of valid ArteOdyssey icons; this
-// instruction makes the constraint visible up front.
-const iconUsageInstruction = [
-  'Icons:',
-  '- Use the `Icon` component with its `name` prop set to one of the names in the catalog enum (e.g. `<Icon name="HistoryIcon" />`).',
-  '- For icon-only actions, use `IconButton` with one `Icon` child: `<IconButton label="History"><Icon name="HistoryIcon" /></IconButton>`.',
-  '- NEVER invent icon names from Material Symbols / Heroicons / Font Awesome (`help_outline`, `menu_book`, `support_agent`, etc.) — they will not resolve and will render as raw text.',
-].join('\n');
-
-// The spec model has `children: string[]` referencing OTHER spec elements
-// by key — there is no way to nest a literal string under a parent. Without
-// a `Text` primitive the LLM defaults to empty `<div />` placeholders
-// inside Heading / Anchor / Card, leaving silent gaps in the preview.
-const textUsageInstruction = [
-  'Text content:',
-  '- Use the `Text` component (`{ "type": "Text", "props": { "content": "..." } }`) for any literal text inside another component — Heading text, Anchor labels, Card body copy, list item text, etc.',
-  '- Children are element keys, NOT raw strings — placing a string directly in `children` is invalid.',
-  '- Components with a dedicated text prop (Button.label, Alert.message, Badge.text, FormControl.label, IconButton.label) take strings via THAT prop, not via `Text` children.',
-  '- If a parent has nothing to say, omit the child entirely — do NOT insert an empty `<div />` placeholder.',
+// Universal spec discipline. Applies to every adapter — these are
+// constraints of the json-render spec model and the catalog contract,
+// not of any specific design system. The codegen also strips unknown
+// props as belt-and-braces, but reminding the model up front is cheaper
+// than repairing the spec downstream.
+const specDisciplineInstruction = [
+  'Spec discipline:',
+  '- Set only the props each component declares in its catalog entry. Unknown props are silently dropped by codegen.',
+  '- `children` is an array of OTHER element keys, not raw strings. To place literal text, use whatever text primitive the catalog provides (look for an entry like `Text`, or a `text` / `label` / `content` prop on the component itself).',
+  '- If a parent has nothing to say, omit the child — do NOT insert an empty placeholder element.',
+  '- Use ONLY components, props, and enum values that appear in the catalog. Do NOT invent component names, icon names, or option values from libraries the catalog does not list (Material Symbols, Heroicons, MUI, etc.) — they will not resolve and the preview will render raw text or an empty slot.',
 ].join('\n');
 
 // Decoro is a design tool — users want to *see* their UI, not run it. The
@@ -98,17 +73,22 @@ const mockupFirstInstruction = [
   '- Only use state bindings / actions when the user EXPLICITLY asks for an interactive prototype.',
 ].join('\n');
 
+// Order matters. Catalog first (the model needs to know what exists),
+// then library context (philosophy + library-specific gotchas from the
+// adapter), then universal Decoro rules (spec discipline, mockup-first,
+// response format). Library-specific guidance comes from
+// `adapter.metadata.promptGuidance` so adapter authors can tell the LLM
+// about THEIR library's quirks without touching this route.
 const systemPrompt = [
   adapter.catalog.prompt({ mode: 'standalone' }),
   '',
   'Library design principles:',
   adapter.metadata.designPrinciples,
+  ...(adapter.metadata.promptGuidance === undefined
+    ? []
+    : ['', adapter.metadata.promptGuidance]),
   '',
-  propsDisciplineInstruction,
-  '',
-  iconUsageInstruction,
-  '',
-  textUsageInstruction,
+  specDisciplineInstruction,
   '',
   mockupFirstInstruction,
   '',

--- a/apps/web/src/app/api/generate/route.ts
+++ b/apps/web/src/app/api/generate/route.ts
@@ -68,6 +68,18 @@ const iconUsageInstruction = [
   '- NEVER invent icon names from Material Symbols / Heroicons / Font Awesome (`help_outline`, `menu_book`, `support_agent`, etc.) — they will not resolve and will render as raw text.',
 ].join('\n');
 
+// The spec model has `children: string[]` referencing OTHER spec elements
+// by key — there is no way to nest a literal string under a parent. Without
+// a `Text` primitive the LLM defaults to empty `<div />` placeholders
+// inside Heading / Anchor / Card, leaving silent gaps in the preview.
+const textUsageInstruction = [
+  'Text content:',
+  '- Use the `Text` component (`{ "type": "Text", "props": { "content": "..." } }`) for any literal text inside another component — Heading text, Anchor labels, Card body copy, list item text, etc.',
+  '- Children are element keys, NOT raw strings — placing a string directly in `children` is invalid.',
+  '- Components with a dedicated text prop (Button.label, Alert.message, Badge.text, FormControl.label, IconButton.label) take strings via THAT prop, not via `Text` children.',
+  '- If a parent has nothing to say, omit the child entirely — do NOT insert an empty `<div />` placeholder.',
+].join('\n');
+
 // Decoro is a design tool — users want to *see* their UI, not run it. The
 // LLM's first instinct is to produce a state-bound interactive prototype
 // (e.g. a chat with `$bindEach: '/messages'` over the message list, or
@@ -95,6 +107,8 @@ const systemPrompt = [
   propsDisciplineInstruction,
   '',
   iconUsageInstruction,
+  '',
+  textUsageInstruction,
   '',
   mockupFirstInstruction,
   '',

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,5 +1,8 @@
+import { adapter } from '../../decoro.config.ts';
 import { HomeShell } from '../components/home-shell.tsx';
 
-const HomePage = () => <HomeShell />;
+const HomePage = () => (
+  <HomeShell tagline={`AI UI generation for ${adapter.metadata.displayName}`} />
+);
 
 export default HomePage;

--- a/apps/web/src/app/preview/page.tsx
+++ b/apps/web/src/app/preview/page.tsx
@@ -50,8 +50,8 @@ const PreviewPage = () => {
             Your generated UI will appear here
           </p>
           <p className="text-fg-mute max-w-md text-sm">
-            Describe a screen on the left — Decoro renders it live with
-            ArteOdyssey components.
+            Describe a screen on the left — Decoro renders it live with{' '}
+            {adapter.metadata.displayName} components.
           </p>
         </div>
       )}

--- a/apps/web/src/components/chat-pane.tsx
+++ b/apps/web/src/components/chat-pane.tsx
@@ -10,6 +10,7 @@ import {
 } from '@k8o/arte-odyssey';
 import { useState } from 'react';
 
+import { adapter } from '../../decoro.config.ts';
 import type { ChatMessage } from '../lib/chat-types.ts';
 
 type Props = {
@@ -137,8 +138,9 @@ export const ChatPane = ({ messages, isStreaming, error, onSubmit }: Props) => {
 const EmptyState = ({ onPick }: { onPick: (text: string) => void }) => (
   <div className="flex h-full flex-col gap-4">
     <p className="text-fg-mute text-sm">
-      Describe a UI in plain language. Decoro turns it into ArteOdyssey
-      components — preview live, copy as TSX. Try one of these to start:
+      Describe a UI in plain language. Decoro turns it into{' '}
+      {adapter.metadata.displayName} components — preview live, copy as TSX. Try
+      one of these to start:
     </p>
     <ul className="grid gap-2">
       {EXAMPLE_PROMPTS.map((example) => (

--- a/apps/web/src/components/code-panel.tsx
+++ b/apps/web/src/components/code-panel.tsx
@@ -107,7 +107,7 @@ export const CodePanel = ({ spec }: Props) => {
         </p>
         <p className="text-fg-mute max-w-md text-sm">
           Describe a screen on the left — Decoro renders it live and shows the
-          matching ArteOdyssey TSX you can copy.
+          matching {adapter.metadata.displayName} TSX you can copy.
         </p>
       </div>
     );

--- a/apps/web/src/components/home-shell.tsx
+++ b/apps/web/src/components/home-shell.tsx
@@ -31,7 +31,17 @@ const OUTPUT_TABS: ReadonlyArray<TabItem<OutputTab>> = [
  * The right pane shows Preview and Code as tabs. Both are kept mounted via
  * `hidden` so the iframe's spec / postMessage handshake survives tab switches.
  */
-export const HomeShell = () => {
+type Props = {
+  /**
+   * Header tagline. Built by the server-side page from
+   * `adapter.metadata.displayName` so this client component doesn't need
+   * to import the adapter binding (which would push it over the
+   * max-dependencies lint).
+   */
+  tagline: string;
+};
+
+export const HomeShell = ({ tagline }: Props) => {
   const { messages, spec, isStreaming, error, send } = useDecoroChat({
     api: '/api/generate',
   });
@@ -46,7 +56,7 @@ export const HomeShell = () => {
   return (
     <div className="bg-bg-surface text-fg-base flex h-dvh flex-col">
       <AppHeader
-        tagline="AI UI generation for ArteOdyssey"
+        tagline={tagline}
         rightSlot={
           <ShareButton
             spec={spec}

--- a/apps/web/src/lib/share-store.ts
+++ b/apps/web/src/lib/share-store.ts
@@ -1,3 +1,9 @@
+// `server-only` is a side-effect import that makes the bundler refuse to
+// include this module in client code. The store touches the filesystem
+// (`node:fs`, `process.cwd()`); an accidental client import would crash
+// the browser bundle.
+// oxlint-disable-next-line eslint-plugin-import(no-unassigned-import)
+import 'server-only';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 
@@ -8,18 +14,17 @@ import {
 } from './share-types.ts';
 
 /**
- * Filesystem-backed snapshot store for Tier 2 sharing (see ADR-013).
+ * Filesystem-backed snapshot store for shareable spec snapshots.
  *
  * Snapshots live as one JSON file per id under `<repo-root>/.decoro-shares/`
  * (gitignored). The store deliberately has no delete or update method:
  * snapshots are immutable for the lifetime of the deployment, and removing
  * a share means deleting the file by hand. Suits a single-user self-host
- * MVP; revisit when sharing reaches Tier 3+ (auth, multi-user, lifecycle).
+ * setup; multi-user / auth / lifecycle features are a follow-up.
  *
  * Storage location is fixed for now. A `decoro.config.ts` extension point
- * (filesystem | vercel-kv | sqlite) is the natural next step when a
- * deployment target needs something other than local disk — left for a
- * follow-up PR per ADR-013.
+ * (filesystem | vercel-kv | sqlite | …) is the natural next step when a
+ * deployment target needs something other than local disk.
  */
 
 const SHARES_DIR = resolve(process.cwd(), '.decoro-shares');

--- a/packages/adapter-arte-odyssey/scripts/generate-catalog.ts
+++ b/packages/adapter-arte-odyssey/scripts/generate-catalog.ts
@@ -99,6 +99,12 @@ const HAND_OVERRIDDEN_COMPONENTS = new Set([
   'Drawer',
   'Modal',
   'Pagination',
+  // IconButton's auto-generated entry hallucinated `startIcon` / `endIcon`
+  // string props that don't exist on the real component (its API takes a
+  // `label` for the tooltip and the icon as children). Skipped here so the
+  // hand-written entry in catalog.ts wins; see also the hand-written `Icon`
+  // entry which gives the LLM the constrained name enum.
+  'IconButton',
 ]);
 
 type CliFlags = { from: string };

--- a/packages/adapter-arte-odyssey/src/adapter.test.tsx
+++ b/packages/adapter-arte-odyssey/src/adapter.test.tsx
@@ -63,6 +63,30 @@ describe('adapter-arte-odyssey', () => {
     expect(tsx).toContain('</Card>');
   });
 
+  it('strips props the catalog schema does not declare (e.g. className on Card)', () => {
+    // Regression: the LLM occasionally hallucinates `className` on
+    // ArteOdyssey components like Card / Button that don't accept it,
+    // producing TSX that fails to compile when pasted into a real codebase.
+    // Codegen runs every element's props through its catalog schema before
+    // serialising; Zod's default safeParse drops unknown keys.
+    const tsx = arteOdysseyAdapter.codeOutput.generate({
+      root: 'card-1',
+      elements: {
+        'card-1': {
+          type: 'Card',
+          props: {
+            width: 'fit',
+            appearance: 'shadow',
+            className: 'p-6 max-w-sm mx-auto my-12',
+          },
+          children: [],
+        },
+      },
+    });
+    expect(tsx).not.toContain('className=');
+    expect(tsx).toContain('<Card width="fit" appearance="shadow" />');
+  });
+
   it('throws on a spec containing an unknown component type', () => {
     expect(() =>
       arteOdysseyAdapter.codeOutput.generate({

--- a/packages/adapter-arte-odyssey/src/adapter.test.tsx
+++ b/packages/adapter-arte-odyssey/src/adapter.test.tsx
@@ -63,6 +63,33 @@ describe('adapter-arte-odyssey', () => {
     expect(tsx).toContain('</Card>');
   });
 
+  it('emits Icon as the named ArteOdyssey component and adds it to the import line', () => {
+    const tsx = arteOdysseyAdapter.codeOutput.generate({
+      root: 'btn',
+      elements: {
+        btn: {
+          type: 'IconButton',
+          props: { label: 'History', size: null, bg: null },
+          children: ['ic'],
+        },
+        ic: {
+          type: 'Icon',
+          props: { name: 'HistoryIcon', size: 'sm' },
+          children: [],
+        },
+      },
+    });
+    // Import line lists the actual icon component, not the meta `Icon` type.
+    expect(tsx).toContain(
+      "import { HistoryIcon, IconButton } from '@k8o/arte-odyssey';",
+    );
+    expect(tsx).not.toContain(', Icon,');
+    expect(tsx).not.toContain(', Icon }');
+    expect(tsx).not.toContain('{ Icon,');
+    // Body emits the icon component directly inside the IconButton.
+    expect(tsx).toContain('<HistoryIcon size="sm" />');
+  });
+
   it('strips props the catalog schema does not declare (e.g. className on Card)', () => {
     // Regression: the LLM occasionally hallucinates `className` on
     // ArteOdyssey components like Card / Button that don't accept it,

--- a/packages/adapter-arte-odyssey/src/adapter.test.tsx
+++ b/packages/adapter-arte-odyssey/src/adapter.test.tsx
@@ -63,6 +63,33 @@ describe('adapter-arte-odyssey', () => {
     expect(tsx).toContain('</Card>');
   });
 
+  it('emits Text as a JSX string-literal expression with no extra import', () => {
+    const tsx = arteOdysseyAdapter.codeOutput.generate({
+      root: 'h',
+      elements: {
+        h: {
+          type: 'Heading',
+          props: { type: 'h2' },
+          children: ['t'],
+        },
+        t: {
+          type: 'Text',
+          props: { content: 'サインイン & "認証"' },
+          children: [],
+        },
+      },
+    });
+    expect(tsx).toContain('<Heading type="h2">');
+    // String literal escapes JSX-significant characters via JSON.stringify.
+    expect(tsx).toContain('{"サインイン & \\"認証\\""}');
+    expect(tsx).toContain('</Heading>');
+    // `Text` is a meta-type — should NOT show up in the import line.
+    expect(tsx).not.toContain(' Text ');
+    expect(tsx).not.toContain(', Text,');
+    expect(tsx).not.toContain('{ Text,');
+    expect(tsx).not.toContain(', Text }');
+  });
+
   it('emits Icon as the named ArteOdyssey component and adds it to the import line', () => {
     const tsx = arteOdysseyAdapter.codeOutput.generate({
       root: 'btn',

--- a/packages/adapter-arte-odyssey/src/catalog.ts
+++ b/packages/adapter-arte-odyssey/src/catalog.ts
@@ -134,6 +134,26 @@ const iconButtonProps = z.object({
 });
 
 /**
+ * Catalog primitive for raw text content. The json-render spec model has
+ * `children: string[]` referring to OTHER spec elements by key — there is
+ * no way to nest a literal string under a parent. Without a `Text`
+ * primitive the LLM either fakes it with an empty `<div />` placeholder
+ * (visible in dogfood as silent gaps inside Heading / Card body / Anchor)
+ * or skips the content entirely.
+ *
+ * Codegen emits `Text` as a JSX expression with a JS string literal —
+ * `{"サインイン"}` — so JSX-significant characters (`<`, `>`, `&`, quotes)
+ * survive the round-trip into the user's codebase.
+ */
+const textProps = z.object({
+  content: z
+    .string()
+    .describe(
+      'The text to render at this position. Use this whenever you need raw text content inside another component (Heading, Anchor, Card body, etc.) — children are otherwise references to other spec elements.',
+    ),
+});
+
+/**
  * Layout HTML element shape (per ADR-012). The only prop is `className`,
  * constrained at the Zod layer to a curated allowlist so the LLM cannot
  * break out of the design system.
@@ -210,6 +230,12 @@ export const catalog = defineCatalog(schema, {
       description:
         'ArteOdyssey icon. Set `name` to one of the listed icons — these are the ONLY available icons. NEVER use Material Symbols / Heroicons / Font Awesome names (`help_outline`, `menu_book`, etc.); they will not resolve and render as raw text.',
     },
+    Text: {
+      props: textProps,
+      slots: [],
+      description:
+        'Raw text content. Use this whenever you need a literal string inside another component (Heading title, Anchor label, Card body copy, list item text, etc.). Without `Text`, children would just be element keys — there is no other way to express text content.',
+    },
     IconButton: {
       props: iconButtonProps,
       slots: ['default'],
@@ -262,3 +288,4 @@ export type ModalProps = z.infer<typeof modalProps>;
 export type PaginationProps = z.infer<typeof paginationProps>;
 export type IconProps = z.infer<typeof iconProps>;
 export type IconButtonProps = z.infer<typeof iconButtonProps>;
+export type TextProps = z.infer<typeof textProps>;

--- a/packages/adapter-arte-odyssey/src/catalog.ts
+++ b/packages/adapter-arte-odyssey/src/catalog.ts
@@ -54,6 +54,86 @@ const paginationProps = z.object({
 });
 
 /**
+ * The complete set of icon components ArteOdyssey ships from
+ * `@k8o/arte-odyssey`. The catalog uses this enum so the LLM can only
+ * pick names that actually resolve to a real export — without it the
+ * model defaults to Material Symbols / Heroicons names (`help_outline`,
+ * `menu_book`, etc.) because that's the dominant chatbot-UI training
+ * data, and those render as raw text in the preview.
+ *
+ * Source of truth: ArteOdyssey's icons module
+ * (`packages/arte-odyssey/src/components/icons/lucide.tsx`). When a new
+ * icon ships there, append the name here and the registry / codegen
+ * picks it up automatically.
+ */
+export const ICON_NAMES = [
+  'AIIcon',
+  'AccessibilityIcon',
+  'AlertIcon',
+  'AtomIcon',
+  'BadIcon',
+  'BlogIcon',
+  'BoringIcon',
+  'CheckIcon',
+  'ChevronIcon',
+  'CloseIcon',
+  'ColorContrastIcon',
+  'ColorInfoIcon',
+  'CopyIcon',
+  'DarkModeIcon',
+  'DifficultIcon',
+  'EasyIcon',
+  'ExternalLinkIcon',
+  'FormIcon',
+  'GoodIcon',
+  'HistoryIcon',
+  'InformativeIcon',
+  'InterestingIcon',
+  'LightModeIcon',
+  'LinkIcon',
+  'ListIcon',
+  'LocationIcon',
+  'MailIcon',
+  'MinusIcon',
+  'MixedColorIcon',
+  'NavigationMenuIcon',
+  'NewsIcon',
+  'PaletteIcon',
+  'PlusIcon',
+  'PrepareIcon',
+  'PublishDateIcon',
+  'RSSIcon',
+  'SendIcon',
+  'ShallowIcon',
+  'ShieldCheckIcon',
+  'SlideIcon',
+  'SparklesIcon',
+  'SubscribeIcon',
+  'TableIcon',
+  'TagIcon',
+  'UpdateDateIcon',
+  'ViewIcon',
+  'ViewOffIcon',
+] as const;
+
+export type IconName = (typeof ICON_NAMES)[number];
+
+const iconProps = z.object({
+  name: z.enum(ICON_NAMES),
+  size: z.enum(['sm', 'md', 'lg']).nullable(),
+});
+
+const iconButtonProps = z.object({
+  label: z
+    .string()
+    .describe(
+      'Tooltip / aria-label. Required — IconButton has no visible text, so the label is the only signal of intent for screen readers and on hover.',
+    ),
+  size: z.enum(['sm', 'md', 'lg']).nullable(),
+  bg: z.enum(['transparent', 'base', 'primary', 'secondary']).nullable(),
+});
+
+/**
  * Layout HTML element shape (per ADR-012). The only prop is `className`,
  * constrained at the Zod layer to a curated allowlist so the LLM cannot
  * break out of the design system.
@@ -124,6 +204,18 @@ export const catalog = defineCatalog(schema, {
       description:
         'Pagination control with prev / next buttons. `totalPages` and `currentPage` are required (1-based). `prevLabel` / `nextLabel` default to Japanese labels in ArteOdyssey; override for English UIs.',
     },
+    Icon: {
+      props: iconProps,
+      slots: [],
+      description:
+        'ArteOdyssey icon. Set `name` to one of the listed icons — these are the ONLY available icons. NEVER use Material Symbols / Heroicons / Font Awesome names (`help_outline`, `menu_book`, etc.); they will not resolve and render as raw text.',
+    },
+    IconButton: {
+      props: iconButtonProps,
+      slots: ['default'],
+      description:
+        'Icon-only button with a tooltip / aria-label. Place exactly one `<Icon name="..." />` child for the visible glyph; `label` is the tooltip text and accessible name. The catalog `IconButton` from the auto-generated set above is overridden here — only this shape is correct.',
+    },
     div: {
       props: layoutElementProps,
       slots: ['default'],
@@ -168,3 +260,5 @@ export type FormControlProps = z.infer<typeof formControlProps>;
 export type DrawerProps = z.infer<typeof drawerProps>;
 export type ModalProps = z.infer<typeof modalProps>;
 export type PaginationProps = z.infer<typeof paginationProps>;
+export type IconProps = z.infer<typeof iconProps>;
+export type IconButtonProps = z.infer<typeof iconButtonProps>;

--- a/packages/adapter-arte-odyssey/src/code-output.ts
+++ b/packages/adapter-arte-odyssey/src/code-output.ts
@@ -1,7 +1,9 @@
 import type { AdapterCodeOutput } from '@decoro/adapter-spec';
 import { serializeProps } from '@json-render/codegen';
-import type { Spec } from '@json-render/core';
+import type { Spec, UIElement } from '@json-render/core';
+import type { z } from 'zod';
 
+import { catalog } from './catalog.ts';
 import {
   GENERATED_IMPORT_TAGS,
   generatedFormatters,
@@ -162,6 +164,31 @@ const formatters: Record<string, Formatter> = {
 
 const MAX_DEPTH = 64;
 
+/**
+ * Strip props that the catalog's Zod schema for this component does not
+ * declare. Zod `safeParse` defaults to dropping unknown keys, so a
+ * successful parse returns the same shape minus anything the LLM hallucinated
+ * (e.g. `className` on `<Card>`, which ArteOdyssey's Card does not accept —
+ * pasting that into a real codebase fails to compile).
+ *
+ * Falls back to the original props on parse failure so a single bad value
+ * doesn't break codegen for the rest of the spec — the user still gets
+ * something to work with even if a prop is malformed.
+ */
+const catalogComponents = (
+  catalog.data as { components: Record<string, { props: z.ZodType }> }
+).components;
+
+const sanitizeProps = (
+  type: string,
+  props: Record<string, unknown>,
+): Record<string, unknown> => {
+  const schema = catalogComponents[type]?.props;
+  if (!schema) return props;
+  const result = schema.safeParse(props);
+  return result.success ? (result.data as Record<string, unknown>) : props;
+};
+
 const renderElement = (
   spec: Spec,
   key: string,
@@ -195,7 +222,11 @@ const renderElement = (
     )
     .filter((s) => s !== '');
   visiting.delete(key);
-  return formatter(element, children, depth);
+  const sanitized: UIElement = {
+    ...element,
+    props: sanitizeProps(element.type, element.props),
+  };
+  return formatter(sanitized, children, depth);
 };
 
 const generate = (spec: Spec): string => {

--- a/packages/adapter-arte-odyssey/src/code-output.ts
+++ b/packages/adapter-arte-odyssey/src/code-output.ts
@@ -3,12 +3,21 @@ import { serializeProps } from '@json-render/codegen';
 import type { Spec, UIElement } from '@json-render/core';
 import type { z } from 'zod';
 
-import { catalog } from './catalog.ts';
+import { ICON_NAMES, catalog } from './catalog.ts';
 import {
   GENERATED_IMPORT_TAGS,
   generatedFormatters,
 } from './code-output.generated.ts';
 import { type Formatter, pad, stripNullish } from './codegen-shared.ts';
+
+const ICON_NAME_SET: ReadonlySet<string> = new Set(ICON_NAMES);
+
+/**
+ * Catalog meta-types whose generated TSX uses different identifiers than
+ * the spec's `type`. These should never appear in the import line directly
+ * — the formatter adds the real import via `extras.addImport`.
+ */
+const META_TYPES = new Set(['Icon']);
 
 const importPath = '@k8o/arte-odyssey';
 
@@ -156,6 +165,41 @@ const formatters: Record<string, Formatter> = {
       `${pad(depth)}/>`,
     ].join('\n');
   },
+  Icon: (element, _children, depth, extras) => {
+    const { name, size } = element.props as { name?: unknown; size?: unknown };
+    if (typeof name !== 'string' || !ICON_NAME_SET.has(name)) {
+      // Defensive: sanitizeProps should reject this, but if a stale spec
+      // slips through, render nothing rather than emit a bad import.
+      return '';
+    }
+    extras.addImport(name);
+    const sizeAttr =
+      typeof size === 'string' && size.length > 0 ? ` size="${size}"` : '';
+    return `${pad(depth)}<${name}${sizeAttr} />`;
+  },
+  IconButton: (element, renderedChildren, depth) => {
+    const propsAttrs = serializeProps(stripNullish(element.props), {
+      quotes: 'double',
+    });
+    if (renderedChildren.length === 0) {
+      return [
+        `${pad(depth)}<IconButton`,
+        `${pad(depth + 1)}${propsAttrs}`,
+        `${pad(depth + 1)}// TODO: wire onAction to your handler`,
+        `${pad(depth + 1)}onAction={() => {}}`,
+        `${pad(depth)}/>`,
+      ].join('\n');
+    }
+    return [
+      `${pad(depth)}<IconButton`,
+      `${pad(depth + 1)}${propsAttrs}`,
+      `${pad(depth + 1)}// TODO: wire onAction to your handler`,
+      `${pad(depth + 1)}onAction={() => {}}`,
+      `${pad(depth)}>`,
+      ...renderedChildren,
+      `${pad(depth)}</IconButton>`,
+    ].join('\n');
+  },
   div: layoutElementFormatter('div'),
   section: layoutElementFormatter('section'),
   header: layoutElementFormatter('header'),
@@ -214,7 +258,7 @@ const renderElement = (
       `adapter-arte-odyssey codegen: missing formatter for "${element.type}". Add an entry to formatters in code-output.ts.`,
     );
   }
-  usedTypes.add(element.type);
+  if (!META_TYPES.has(element.type)) usedTypes.add(element.type);
   visiting.add(key);
   const children = (element.children ?? [])
     .map((childKey) =>
@@ -226,7 +270,11 @@ const renderElement = (
     ...element,
     props: sanitizeProps(element.type, element.props),
   };
-  return formatter(sanitized, children, depth);
+  return formatter(sanitized, children, depth, {
+    addImport: (name) => {
+      usedTypes.add(name);
+    },
+  });
 };
 
 const generate = (spec: Spec): string => {

--- a/packages/adapter-arte-odyssey/src/code-output.ts
+++ b/packages/adapter-arte-odyssey/src/code-output.ts
@@ -13,11 +13,15 @@ import { type Formatter, pad, stripNullish } from './codegen-shared.ts';
 const ICON_NAME_SET: ReadonlySet<string> = new Set(ICON_NAMES);
 
 /**
- * Catalog meta-types whose generated TSX uses different identifiers than
- * the spec's `type`. These should never appear in the import line directly
- * — the formatter adds the real import via `extras.addImport`.
+ * Catalog meta-types that don't correspond to a single named import:
+ * - `Icon` resolves to one of 47 named icon components via `name` (the
+ *   formatter calls `extras.addImport(name)` to pick the right one).
+ * - `Text` emits inline as a JSX expression with a string literal, no
+ *   component reference at all.
+ *
+ * Keep them out of the auto-collected import list.
  */
-const META_TYPES = new Set(['Icon']);
+const META_TYPES = new Set(['Icon', 'Text']);
 
 const importPath = '@k8o/arte-odyssey';
 
@@ -164,6 +168,15 @@ const formatters: Record<string, Formatter> = {
       `${pad(depth + 1)}onPageChange={(_page) => {}}`,
       `${pad(depth)}/>`,
     ].join('\n');
+  },
+  Text: (element, _children, depth) => {
+    const { content } = element.props as { content?: unknown };
+    const text = typeof content === 'string' ? content : '';
+    if (text === '') return '';
+    // JSX expression with a JS string literal so any character (`<`, `>`,
+    // `&`, quotes, braces) survives copy-paste into a real codebase.
+    // Same approach as the Button label formatter.
+    return `${pad(depth)}{${JSON.stringify(text)}}`;
   },
   Icon: (element, _children, depth, extras) => {
     const { name, size } = element.props as { name?: unknown; size?: unknown };

--- a/packages/adapter-arte-odyssey/src/codegen-shared.ts
+++ b/packages/adapter-arte-odyssey/src/codegen-shared.ts
@@ -9,10 +9,21 @@ export const stripNullish = (props: Record<string, unknown>) =>
     Object.entries(props).filter(([, v]) => v !== null && v !== undefined),
   );
 
+/**
+ * `extras.addImport(name)` lets a formatter pull in an additional named
+ * export from `@k8o/arte-odyssey` beyond the element's own type. Used by
+ * the Icon formatter to emit `<HistoryIcon />` (the icon component) while
+ * the catalog type stays as the meta `Icon`.
+ */
+export type FormatterExtras = {
+  addImport: (name: string) => void;
+};
+
 export type Formatter = (
   element: UIElement,
   renderedChildren: string[],
   depth: number,
+  extras: FormatterExtras,
 ) => string;
 
 /**
@@ -23,7 +34,7 @@ export type Formatter = (
  */
 export const passthroughFormatter =
   (tag: string): Formatter =>
-  (element, renderedChildren, depth) => {
+  (element, renderedChildren, depth, _extras) => {
     const propsAttrs = serializeProps(stripNullish(element.props), {
       quotes: 'double',
     });

--- a/packages/adapter-arte-odyssey/src/metadata.ts
+++ b/packages/adapter-arte-odyssey/src/metadata.ts
@@ -1,5 +1,35 @@
 import type { AdapterMetadata } from '@decoro/adapter-spec';
 
+/**
+ * Library-specific "do this, not that" rules surfaced as `promptGuidance`.
+ * Each entry exists because the LLM hallucinated something that wouldn't
+ * compile or wouldn't render against ArteOdyssey:
+ *   - `className` on Button/Card/etc. — they style themselves, the
+ *     attribute would just be silently dropped at type-check time.
+ *   - Material Symbols / Heroicons names — ArteOdyssey ships its own icon
+ *     set; foreign names render as raw text in the preview.
+ *   - Empty `<div />` placeholders for text — there is no "raw string
+ *     child" in the spec model, you have to use the `Text` primitive.
+ *
+ * Universal Decoro guidance (response format, spec model rules,
+ * mockup-first preference) lives in `apps/web/src/app/api/generate/route.ts`
+ * and applies regardless of which adapter is bound.
+ */
+const promptGuidance = [
+  'Prop discipline (ArteOdyssey-specific):',
+  '- Do NOT add `className` to ArteOdyssey components (Button, Card, FormControl, TextField, etc.). They control their own styling.',
+  '- `className` is allowed ONLY on layout HTML elements (div, section, header, main), and only with the allowlisted utility tokens shown in their schema.',
+  '',
+  'Icons (ArteOdyssey-specific):',
+  '- Use the `Icon` component with its `name` prop set to one of the names in the catalog enum (e.g. `<Icon name="HistoryIcon" />`).',
+  '- For icon-only actions, use `IconButton` with one `Icon` child: `<IconButton label="History"><Icon name="HistoryIcon" /></IconButton>`.',
+  '- NEVER use Material Symbols / Heroicons / Font Awesome names (`help_outline`, `menu_book`, `support_agent`, etc.) — they will not resolve and will render as raw text.',
+  '',
+  'Text content (ArteOdyssey-specific):',
+  '- Use the `Text` component (`{ "type": "Text", "props": { "content": "..." } }`) for any literal text inside another component — Heading text, Anchor labels, Card body copy, list item text, etc.',
+  '- Components with a dedicated text prop (Button.label, Alert.message, Badge.text, FormControl.label, IconButton.label) take strings via THAT prop, not via `Text` children.',
+].join('\n');
+
 export const metadata: AdapterMetadata = {
   name: '@k8o/arte-odyssey',
   version: '7.0.1',
@@ -11,4 +41,5 @@ export const metadata: AdapterMetadata = {
     'Sizes: sm / md / lg. Default to md unless density demands otherwise.',
     'Spacing and rounded corners follow the library defaults — do not override with raw Tailwind unless asked.',
   ].join('\n'),
+  promptGuidance,
 };

--- a/packages/adapter-arte-odyssey/src/metadata.ts
+++ b/packages/adapter-arte-odyssey/src/metadata.ts
@@ -32,6 +32,7 @@ const promptGuidance = [
 
 export const metadata: AdapterMetadata = {
   name: '@k8o/arte-odyssey',
+  displayName: 'ArteOdyssey',
   version: '7.0.1',
   designPrinciples: [
     'ArteOdyssey is a React + TypeScript + Tailwind CSS 4 design system.',

--- a/packages/adapter-arte-odyssey/src/registry.tsx
+++ b/packages/adapter-arte-odyssey/src/registry.tsx
@@ -2,16 +2,18 @@ import type {
   ComponentRegistry,
   ComponentRenderProps,
 } from '@json-render/react';
+import * as arteOdyssey from '@k8o/arte-odyssey';
 import {
   Alert,
   Button,
   Card,
   Drawer,
   FormControl,
+  IconButton,
   Modal,
   Pagination,
 } from '@k8o/arte-odyssey';
-import { createElement } from 'react';
+import { type ComponentType, createElement } from 'react';
 
 import type {
   AlertProps,
@@ -19,6 +21,8 @@ import type {
   CardProps,
   DrawerProps,
   FormControlProps,
+  IconButtonProps,
+  IconProps,
   LayoutElementProps,
   ModalProps,
   PaginationProps,
@@ -129,6 +133,38 @@ const ModalRenderer = ({
   );
 };
 
+/**
+ * Look up an ArteOdyssey icon component by name. The Catalog Zod enum
+ * already constrains `name` to a known icon, so the cast is safe — but we
+ * still null-check to avoid a hard crash if a stale spec carries a name
+ * that no longer exists in the library (e.g. after an icon rename).
+ */
+const IconRenderer = ({ element }: ComponentRenderProps<IconProps>) => {
+  const { name, size } = element.props;
+  const Component = (arteOdyssey as Record<string, unknown>)[name] as
+    | ComponentType<{ size?: 'sm' | 'md' | 'lg' }>
+    | undefined;
+  if (!Component) return null;
+  return <Component size={size ?? undefined} />;
+};
+
+const IconButtonRenderer = ({
+  element,
+  children,
+}: ComponentRenderProps<IconButtonProps>) => {
+  const { label, size, bg } = element.props;
+  return (
+    <IconButton
+      label={label}
+      size={size ?? undefined}
+      bg={bg ?? undefined}
+      onAction={noop}
+    >
+      {children}
+    </IconButton>
+  );
+};
+
 const PaginationRenderer = ({
   element,
 }: ComponentRenderProps<PaginationProps>) => {
@@ -176,6 +212,8 @@ export const registry: ComponentRegistry = {
   Drawer: DrawerRenderer,
   Modal: ModalRenderer,
   Pagination: PaginationRenderer,
+  Icon: IconRenderer,
+  IconButton: IconButtonRenderer,
   div: layoutElementRenderer('div'),
   section: layoutElementRenderer('section'),
   header: layoutElementRenderer('header'),

--- a/packages/adapter-arte-odyssey/src/registry.tsx
+++ b/packages/adapter-arte-odyssey/src/registry.tsx
@@ -26,6 +26,7 @@ import type {
   LayoutElementProps,
   ModalProps,
   PaginationProps,
+  TextProps,
 } from './catalog.ts';
 import { generatedRegistry } from './registry.generated.tsx';
 
@@ -134,6 +135,16 @@ const ModalRenderer = ({
 };
 
 /**
+ * Render the spec's `Text` primitive as plain text. React accepts a string
+ * as a valid child / element, so the renderer returns the content directly.
+ * Without this, the spec model (`children: string[]` referencing other
+ * elements) has no way to express raw text content, and the LLM was
+ * reaching for empty `<div />` placeholders inside Heading / Anchor / Card.
+ */
+const TextRenderer = ({ element }: ComponentRenderProps<TextProps>) =>
+  element.props.content;
+
+/**
  * Look up an ArteOdyssey icon component by name. The Catalog Zod enum
  * already constrains `name` to a known icon, so the cast is safe — but we
  * still null-check to avoid a hard crash if a stale spec carries a name
@@ -214,6 +225,7 @@ export const registry: ComponentRegistry = {
   Pagination: PaginationRenderer,
   Icon: IconRenderer,
   IconButton: IconButtonRenderer,
+  Text: TextRenderer,
   div: layoutElementRenderer('div'),
   section: layoutElementRenderer('section'),
   header: layoutElementRenderer('header'),

--- a/packages/adapter-spec/src/index.ts
+++ b/packages/adapter-spec/src/index.ts
@@ -13,24 +13,21 @@ export type AdapterMetadata = {
 /**
  * Mapping from Catalog component name to a concrete component implementation.
  *
- * Parametric in `TComponent` so `@decoro/core` can stay framework-agnostic
- * (per ADR-004). Concrete adapters specialize this — e.g.
- * `adapter-arte-odyssey` will pin it to React component types.
+ * Parametric in `TComponent` so the core stays framework-agnostic.
+ * Concrete adapters specialize this — e.g. `adapter-arte-odyssey` pins it
+ * to React component types.
  */
 export type AdapterRegistry<TComponent = unknown> = Record<string, TComponent>;
 
 /**
- * Hooks an adapter exposes for turning a `json-render` Spec into TSX.
+ * Hooks an adapter exposes for turning a `json-render` Spec into source
+ * code.
  *
- * **MVP-only contract.** Today this shape assumes a single TSX string and a
- * single ES module import path — the React + ArteOdyssey pairing the MVP
- * targets. That assumption leaks "TSX / React" into adapter-spec, which is
- * supposed to be framework-agnostic. The next non-React adapter (Vue,
- * Svelte, Solid) will force this shape to grow into something like
- * `{ filename, content }[]` keyed by output target. Per ADR-004 we do not
- * pre-abstract — this comment is the contract that the broader shape is on
- * the first-release roadmap (see docs/mvp-scope.md "Beyond MVP"), not in
- * MVP itself.
+ * **Current shape assumes a single TSX file and a single ES module import
+ * path** — the React + ArteOdyssey pairing this MVP targets. Adding a
+ * non-React adapter (Vue, Svelte, Solid) will need this to grow into a
+ * multi-file output shape like `{ filename, content }[]`. Until that
+ * happens we keep the contract minimal.
  *
  * - `importPath`: where the generated code imports components from (e.g.
  *   `'@k8o/arte-odyssey'`).
@@ -46,10 +43,9 @@ export type AdapterCodeOutput = {
 
 /**
  * What an adapter must expose so Decoro can drive UI generation against a
- * specific component library.
- *
- * Intentionally minimal. Fields will harden as `adapter-arte-odyssey` (M3)
- * and the codegen wiring (M9) force them to.
+ * specific component library. Intentionally minimal — implement these four
+ * fields and Decoro will route through `decoro.config.ts`'s `adapter`
+ * binding.
  */
 export type Adapter<TComponent = unknown> = {
   metadata: AdapterMetadata;

--- a/packages/adapter-spec/src/index.ts
+++ b/packages/adapter-spec/src/index.ts
@@ -3,11 +3,24 @@ import type { Catalog, Spec } from '@json-render/core';
 /**
  * Free-form description of the target component library, surfaced in the UI
  * and threaded into the generation prompt.
+ *
+ * - `designPrinciples`: high-level philosophy ("prefer semantic components",
+ *   "use primary color for the main CTA", etc.). Read by the operator
+ *   building intuition for the library and by the LLM as background
+ *   context.
+ * - `promptGuidance`: concrete "do this, not that" rules the LLM tends to
+ *   trip on for THIS specific library — the right component for icons,
+ *   props that don't accept `className`, library-specific text primitives,
+ *   etc. Kept separate from `designPrinciples` because Decoro's universal
+ *   prompt (response format, mockup-first generation, spec model rules)
+ *   sits beside it in the system prompt; mixing them dilutes both. Leave
+ *   undefined if the library has no known LLM gotchas worth calling out.
  */
 export type AdapterMetadata = {
   name: string;
   version: string;
   designPrinciples: string;
+  promptGuidance?: string;
 };
 
 /**

--- a/packages/adapter-spec/src/index.ts
+++ b/packages/adapter-spec/src/index.ts
@@ -4,6 +4,13 @@ import type { Catalog, Spec } from '@json-render/core';
  * Free-form description of the target component library, surfaced in the UI
  * and threaded into the generation prompt.
  *
+ * - `name`: package identifier (e.g. `'@k8o/arte-odyssey'`). Stable id;
+ *   not user-facing.
+ * - `displayName`: short proper-noun label shown in the Decoro UI (header
+ *   tagline, empty-state copy, etc.). Use the human-readable brand name
+ *   ("ArteOdyssey", "Material UI", "Chakra UI") rather than the package
+ *   id.
+ * - `version`: the library version this adapter targets.
  * - `designPrinciples`: high-level philosophy ("prefer semantic components",
  *   "use primary color for the main CTA", etc.). Read by the operator
  *   building intuition for the library and by the LLM as background
@@ -18,6 +25,7 @@ import type { Catalog, Spec } from '@json-render/core';
  */
 export type AdapterMetadata = {
   name: string;
+  displayName: string;
   version: string;
   designPrinciples: string;
   promptGuidance?: string;

--- a/packages/llm-config/package.json
+++ b/packages/llm-config/package.json
@@ -15,6 +15,7 @@
     "@ai-sdk/anthropic": "3.0.71",
     "@ai-sdk/gateway": "3.0.104",
     "@ai-sdk/google": "3.0.64",
+    "@ai-sdk/provider": "3.0.8",
     "ai": "6.0.168",
     "server-only": "0.0.1"
   }

--- a/packages/llm-config/src/index.ts
+++ b/packages/llm-config/src/index.ts
@@ -10,6 +10,8 @@ import { createGateway } from '@ai-sdk/gateway';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import type { LanguageModel } from 'ai';
 
+import { createSubprocessClaude } from './subprocess-claude.ts';
+
 /**
  * LLM configuration consumed by `createModel`. The shape is a discriminated
  * union so adding `provider: 'openai'` later only adds branches — existing
@@ -24,11 +26,17 @@ import type { LanguageModel } from 'ai';
  *     supported provider (model strings look like `anthropic/...`,
  *     `google/...`, `openai/...`). Vercel ships a free monthly credit, so
  *     this is usually the lowest-friction path.
+ *   - `subprocess-claude` shells out to the locally installed `claude` CLI
+ *     and adapts its `--print --output-format stream-json` output. Lets
+ *     you monkey-test against your Claude subscription with no per-token
+ *     API charges. Process spawn overhead (~1.5s/turn) makes this unfit
+ *     for tests / CI; use the API-backed providers there.
  */
 export type LlmConfig =
   | { provider: 'anthropic'; model: string; apiKey?: string }
   | { provider: 'google'; model: string; apiKey?: string }
-  | { provider: 'gateway'; model: string; apiKey?: string };
+  | { provider: 'gateway'; model: string; apiKey?: string }
+  | { provider: 'subprocess-claude'; model: string; command?: string };
 
 /**
  * Resolve a config into an AI SDK model instance. Server-side only — never
@@ -48,6 +56,9 @@ export const createModel = (config: LlmConfig): LanguageModel => {
     case 'gateway': {
       const gateway = createGateway({ apiKey: config.apiKey });
       return gateway(config.model);
+    }
+    case 'subprocess-claude': {
+      return createSubprocessClaude(config.model, { command: config.command });
     }
     default: {
       // Exhaustiveness guard. Adding a new provider must also add a case.

--- a/packages/llm-config/src/index.ts
+++ b/packages/llm-config/src/index.ts
@@ -13,24 +13,23 @@ import type { LanguageModel } from 'ai';
 import { createSubprocessClaude } from './subprocess-claude.ts';
 
 /**
- * LLM configuration consumed by `createModel`. The shape is a discriminated
- * union so adding `provider: 'openai'` later only adds branches — existing
- * call sites stay exhaustive.
+ * LLM configuration consumed by `createModel`. Discriminated union so
+ * adding `provider: 'openai'` later only adds branches — existing call
+ * sites stay exhaustive.
  *
- * MVP-time provider matrix (per ADR-005):
- *   - `anthropic` is the verified target for the value-validation hypothesis
- *     (json-render structured output is strongest here).
- *   - `google` is wired so contributors without an Anthropic API key can
- *     still smoke-test on Gemini's free tier.
- *   - `gateway` routes through Vercel AI Gateway — one key reaches every
- *     supported provider (model strings look like `anthropic/...`,
- *     `google/...`, `openai/...`). Vercel ships a free monthly credit, so
- *     this is usually the lowest-friction path.
- *   - `subprocess-claude` shells out to the locally installed `claude` CLI
- *     and adapts its `--print --output-format stream-json` output. Lets
- *     you monkey-test against your Claude subscription with no per-token
- *     API charges. Process spawn overhead (~1.5s/turn) makes this unfit
- *     for tests / CI; use the API-backed providers there.
+ * Supported providers:
+ *   - `anthropic`: Claude via the Anthropic API (the most thoroughly
+ *     tested target for Decoro's structured JSON output).
+ *   - `google`: Gemini direct, useful when you only have a Google API
+ *     key (Gemini's free tier is generous).
+ *   - `gateway`: Vercel AI Gateway — one key reaches every supported
+ *     provider (model strings look like `anthropic/...`, `google/...`,
+ *     `openai/...`). Usually the lowest-friction path.
+ *   - `subprocess-claude`: shells out to the locally installed `claude`
+ *     CLI and adapts its `--print --output-format stream-json` output.
+ *     Lets you monkey-test against your Claude subscription with no
+ *     per-token API charges. Process spawn overhead (~1.5s/turn) makes
+ *     this unfit for tests / CI; use the API-backed providers there.
  */
 export type LlmConfig =
   | { provider: 'anthropic'; model: string; apiKey?: string }

--- a/packages/llm-config/src/subprocess-claude.ts
+++ b/packages/llm-config/src/subprocess-claude.ts
@@ -1,0 +1,294 @@
+import { spawn } from 'node:child_process';
+
+import type {
+  LanguageModelV2,
+  LanguageModelV2CallOptions,
+  LanguageModelV2FinishReason,
+  LanguageModelV2Prompt,
+  LanguageModelV2StreamPart,
+  LanguageModelV2TextPart,
+  LanguageModelV2Usage,
+} from '@ai-sdk/provider';
+
+/**
+ * Spawn a local `claude` CLI process and adapt its `--print --output-format
+ * stream-json` output into a Vercel AI SDK `LanguageModelV2`. Use case:
+ * monkey-testing Decoro against your ChatGPT-style Claude subscription
+ * without paying per-token API charges.
+ *
+ * Trade-offs vs. real API providers:
+ *   - Latency: each call spawns a process (~1.5s overhead even for empty
+ *     prompts). Fine for manual dogfood, painful in tests / CI.
+ *   - Auth: relies on whatever account `claude` is logged into on this
+ *     machine. **Critically**, when this provider is used from a server
+ *     started outside an interactive `claude` session (e.g. plain
+ *     `pnpm dev`), the CLI cannot reach its macOS Keychain credentials
+ *     and exits 1 with "Not logged in". Workaround: run
+ *     `claude setup-token` to mint a long-lived token and export it as
+ *     `CLAUDE_CODE_OAUTH_TOKEN` (e.g. via `.env.local`). The spawned
+ *     CLI picks it up from process.env without keychain access.
+ *   - Output shape: the CLI emits assistant turns plus tool / status events.
+ *     We discard everything except `text_delta` events, which is what the
+ *     Vercel AI SDK actually consumes.
+ *   - Tool use: explicitly disabled (`--tools ""`, no MCP, no slash
+ *     commands) so Claude responds purely as a chat completion. Decoro
+ *     does NOT want Claude trying to edit local files mid-generation.
+ */
+export type SubprocessClaudeOptions = {
+  /** Path / name of the CLI binary. Defaults to `claude` on PATH. */
+  command?: string;
+  /** Extra args appended after the built-in flags but before the prompt. */
+  extraArgs?: string[];
+};
+
+type ClaudeStreamEvent = {
+  type?: string;
+  event?: {
+    type?: string;
+    delta?: { type?: string; text?: string };
+  };
+  usage?: { input_tokens?: number; output_tokens?: number };
+  message?: string;
+};
+
+const collectText = (parts: ReadonlyArray<{ type: string }>): string =>
+  parts
+    .flatMap((p): string[] =>
+      p.type === 'text' ? [(p as LanguageModelV2TextPart).text] : [],
+    )
+    .join('');
+
+/**
+ * Flatten an AI SDK V2 prompt into the two pieces the Claude CLI accepts:
+ * a single `--system-prompt` string and a single positional user prompt.
+ *
+ * Conversation history is concatenated into the user prompt with role
+ * labels — the LLM sees the full back-and-forth, including its own prior
+ * JSONL patches, so iteration prompts (`buildUserPrompt`) work the same as
+ * with API-backed providers. Tool / file / image parts are dropped:
+ * Decoro's `/api/generate` only ever sends text, and the CLI doesn't have
+ * a clean way to round-trip the rest.
+ */
+const flattenPrompt = (
+  prompt: LanguageModelV2Prompt,
+): { system: string; user: string } => {
+  const systemParts: string[] = [];
+  const conversation: string[] = [];
+  for (const msg of prompt) {
+    if (msg.role === 'system') {
+      systemParts.push(msg.content);
+      continue;
+    }
+    if (msg.role === 'tool') continue;
+    const text = collectText(msg.content);
+    if (text === '') continue;
+    const label = msg.role === 'assistant' ? 'ASSISTANT' : 'USER';
+    conversation.push(`${label}:\n${text}`);
+  }
+  return {
+    system: systemParts.join('\n\n'),
+    user: conversation.join('\n\n'),
+  };
+};
+
+const buildArgs = (
+  modelId: string,
+  system: string,
+  user: string,
+  extraArgs: readonly string[],
+): string[] => [
+  '-p',
+  '--output-format',
+  'stream-json',
+  '--verbose',
+  '--include-partial-messages',
+  '--no-session-persistence',
+  '--strict-mcp-config',
+  '--mcp-config',
+  '{"mcpServers":{}}',
+  '--disable-slash-commands',
+  '--tools',
+  '',
+  '--model',
+  modelId,
+  '--system-prompt',
+  system,
+  ...extraArgs,
+  user,
+];
+
+const createClaudeStream = (
+  modelId: string,
+  opts: SubprocessClaudeOptions,
+  callOptions: LanguageModelV2CallOptions,
+): ReadableStream<LanguageModelV2StreamPart> => {
+  const { system, user } = flattenPrompt(callOptions.prompt);
+  const args = buildArgs(modelId, system, user, opts.extraArgs ?? []);
+  const command = opts.command ?? 'claude';
+
+  return new ReadableStream<LanguageModelV2StreamPart>({
+    start(controller) {
+      const proc = spawn(command, args, {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        signal: callOptions.abortSignal,
+      });
+
+      const textBlockId = 'text-0';
+      let textStarted = false;
+      let textEnded = false;
+      let buffer = '';
+      let stderr = '';
+      let inputTokens: number | undefined;
+      let outputTokens: number | undefined;
+      let finishReason: LanguageModelV2FinishReason = 'unknown';
+
+      controller.enqueue({ type: 'stream-start', warnings: [] });
+
+      const handleEvent = (event: ClaudeStreamEvent) => {
+        if (event.type === 'stream_event') {
+          const inner = event.event;
+          if (
+            inner?.type === 'content_block_delta' &&
+            inner.delta?.type === 'text_delta' &&
+            typeof inner.delta.text === 'string'
+          ) {
+            if (!textStarted) {
+              controller.enqueue({ type: 'text-start', id: textBlockId });
+              textStarted = true;
+            }
+            controller.enqueue({
+              type: 'text-delta',
+              id: textBlockId,
+              delta: inner.delta.text,
+            });
+          }
+          return;
+        }
+        if (event.type === 'result') {
+          inputTokens = event.usage?.input_tokens;
+          outputTokens = event.usage?.output_tokens;
+          finishReason = 'stop';
+        }
+      };
+
+      // stdio is `[ignore, pipe, pipe]`, so both streams are non-null.
+      proc.stderr.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString('utf8');
+      });
+
+      proc.stdout.on('data', (chunk: Buffer) => {
+        buffer += chunk.toString('utf8');
+        for (;;) {
+          const nl = buffer.indexOf('\n');
+          if (nl < 0) break;
+          const line = buffer.slice(0, nl).trim();
+          buffer = buffer.slice(nl + 1);
+          if (line === '') continue;
+          try {
+            handleEvent(JSON.parse(line) as ClaudeStreamEvent);
+          } catch {
+            // Non-JSON line (banner / debug) — ignore. The stream-json
+            // format is one JSON object per line; anything that fails to
+            // parse is noise we can safely drop.
+          }
+        }
+      });
+
+      const finalize = (err?: Error) => {
+        if (textStarted && !textEnded) {
+          controller.enqueue({ type: 'text-end', id: textBlockId });
+          textEnded = true;
+        }
+        if (err) {
+          controller.enqueue({ type: 'error', error: err });
+          finishReason = 'error';
+        }
+        const usage: LanguageModelV2Usage = {
+          inputTokens,
+          outputTokens,
+          totalTokens:
+            inputTokens === undefined || outputTokens === undefined
+              ? undefined
+              : inputTokens + outputTokens,
+        };
+        controller.enqueue({ type: 'finish', usage, finishReason });
+        controller.close();
+      };
+
+      proc.on('error', (err) => {
+        finalize(err);
+      });
+
+      proc.on('close', (code) => {
+        if (code === 0) {
+          finalize();
+          return;
+        }
+        // The CLI exits 1 with no stderr when it can't reach its
+        // credentials — most commonly when launched from a process tree
+        // (e.g. Next.js dev) that doesn't share macOS Keychain access
+        // with the user's interactive `claude` install. Surface a
+        // pointer rather than the bare exit code so the user knows
+        // where to look.
+        const detail = stderr.trim() || buffer.trim();
+        const hint =
+          detail === '' || /not logged in/i.test(detail)
+            ? ' (claude is unauthenticated in this process — try `claude setup-token` and export CLAUDE_CODE_OAUTH_TOKEN in .env.local)'
+            : '';
+        finalize(
+          new Error(
+            `claude CLI exited with code ${String(code)}: ${detail || '(no stderr)'}${hint}`,
+          ),
+        );
+      });
+    },
+  });
+};
+
+export const createSubprocessClaude = (
+  modelId: string,
+  opts: SubprocessClaudeOptions = {},
+): LanguageModelV2 => {
+  const doStream = (callOptions: LanguageModelV2CallOptions) =>
+    Promise.resolve({ stream: createClaudeStream(modelId, opts, callOptions) });
+
+  return {
+    specificationVersion: 'v2',
+    provider: 'subprocess-claude',
+    modelId,
+    supportedUrls: {},
+
+    doStream,
+
+    async doGenerate(callOptions) {
+      const { stream } = await doStream(callOptions);
+      const reader = stream.getReader();
+      let text = '';
+      let usage: LanguageModelV2Usage = {
+        inputTokens: undefined,
+        outputTokens: undefined,
+        totalTokens: undefined,
+      };
+      let finishReason: LanguageModelV2FinishReason = 'unknown';
+      for (;;) {
+        // Sequential await is required: chunks arrive in order from the
+        // subprocess stream, and we need each one before deciding what to
+        // do with it. Promise.all wouldn't apply.
+        // oxlint-disable-next-line eslint(no-await-in-loop)
+        const { value, done } = await reader.read();
+        if (done) break;
+        if (value.type === 'text-delta') text += value.delta;
+        else if (value.type === 'finish') {
+          ({ usage } = value);
+          ({ finishReason } = value);
+        }
+      }
+      return {
+        content: text === '' ? [] : [{ type: 'text', text }],
+        finishReason,
+        usage,
+        warnings: [],
+      };
+    },
+  };
+};

--- a/packages/llm-config/src/subprocess-claude.ts
+++ b/packages/llm-config/src/subprocess-claude.ts
@@ -1,3 +1,10 @@
+// `server-only` is a side-effect import that makes the bundler refuse to
+// include this module in client code. We spawn a child process here;
+// `node:child_process` is unavailable in the browser, and a stray client
+// import would otherwise produce a confusing build error far from the
+// real cause.
+// oxlint-disable-next-line eslint-plugin-import(no-unassigned-import)
+import 'server-only';
 import { spawn } from 'node:child_process';
 
 import type {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,6 +196,9 @@ importers:
       '@ai-sdk/google':
         specifier: 3.0.64
         version: 3.0.64(zod@4.3.6)
+      '@ai-sdk/provider':
+        specifier: 3.0.8
+        version: 3.0.8
       ai:
         specifier: 6.0.168
         version: 6.0.168(zod@4.3.6)


### PR DESCRIPTION
## Reported

User pasted a generated sign-in card and got:

\`\`\`tsx
<Card width="fit" appearance="shadow" className="p-6 max-w-sm mx-auto my-12">
\`\`\`

which doesn't compile against ArteOdyssey's \`Card\` — \`CardProps = { width?, appearance? }\`, no \`className\`. The LLM hallucinated a \`className\` because most React component libraries accept it; ours deliberately doesn't (per ADR-012 only layout HTML elements take className, and only from a curated allowlist).

## Two-pronged fix

### 1. Codegen-side (defensive) — `packages/adapter-arte-odyssey/src/code-output.ts`

Every element's props now run through the catalog's Zod schema (\`safeParse\`) before reaching the formatter. Zod's default behavior strips unknown keys, so anything the LLM hallucinated drops out before JSX is emitted.

\`\`\`ts
const sanitizeProps = (type, props) => {
  const schema = catalogComponents[type]?.props;
  if (!schema) return props;
  const result = schema.safeParse(props);
  return result.success ? result.data : props;
};
\`\`\`

Falls back to original props on parse failure so a single bad value doesn't break codegen for the rest of the spec — the user still gets something to work with even if a prop is malformed.

Layout HTML elements (\`div\`, \`section\`, \`header\`, \`main\`) continue to accept className via their \`layoutElementProps\` schema — \`sanitizeProps\` preserves allowlisted className for those. ADR-012 contract intact.

### 2. Prompt-side (preventive) — `apps/web/src/app/api/generate/route.ts`

New "Prop discipline" instruction in the system prompt:

\`\`\`
- Set only the props each component declares in its catalog entry.
- Do NOT add \`className\` to ArteOdyssey components (Button, Card,
  FormControl, TextField, etc.). They control their own styling.
- \`className\` is allowed ONLY on layout HTML elements (div, section,
  header, main), and only with the allowlisted utility tokens shown
  in their schema.
\`\`\`

\`Catalog.prompt()\` already exposes the schemas, but Gemini Flash in particular tends to override them — the explicit reminder is cheap insurance.

## Regression test

\`\`\`ts
it('strips props the catalog schema does not declare (e.g. className on Card)', () => {
  const tsx = arteOdysseyAdapter.codeOutput.generate({
    root: 'card-1',
    elements: {
      'card-1': {
        type: 'Card',
        props: { width: 'fit', appearance: 'shadow', className: 'p-6 max-w-sm mx-auto my-12' },
        children: [],
      },
    },
  });
  expect(tsx).not.toContain('className=');
  expect(tsx).toContain('<Card width="fit" appearance="shadow" />');
});
\`\`\`

## Test plan

- [x] \`pnpm typecheck\` (4 packages, all pass)
- [x] \`pnpm test\` (16/16 — the new regression test included)
- [x] \`pnpm check\` (59 files formatted, 42 lint-clean)
- [x] Manual: dev server picks up the prompt change automatically; live preview unchanged (the renderer was already tolerant of unknown props, only the codegen produced bad TSX)
- [ ] Reviewer: regenerate a sign-in card with the same prompt that hit the bug; verify the Card line no longer carries className

## Notes

The codegen fix is the load-bearing one — the prompt update is belt-and-braces but doesn't replace the defensive strip. If the LLM ignores the prompt (which it sometimes does), the spec still arrives with hallucinated className; the codegen layer is what actually keeps it out of the user's clipboard.