### PR TITLE
feat: per-team conversation history + server-side streaming

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,9 @@ ANTHROPIC_API_KEY=
 # Google Gemini direct — obtain from https://aistudio.google.com/apikey
 # (free tier)
 GOOGLE_GENERATIVE_AI_API_KEY=
+#
+# PostgreSQL connection string for shares + conversation history (ADR-015).
+# The default value matches the local Postgres started by `docker compose up`
+# at the repo root; override for production deployments (Neon / Supabase /
+# self-hosted Postgres).
+DATABASE_URL=postgres://decoro:decoro@localhost:5432/decoro

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ settings.local.json
 # Design docs are kept local-only for now
 docs/
 
-# Share-snapshot store (Tier 2 sharing — see ADR-013).
-# Each file is `<id>.json` with a public conversation snapshot.
+# Share-snapshot store (legacy; superseded by Postgres in ADR-015).
+# One JSON file per snapshot; remove once `pnpm migrate:from-fs` has run.
 .decoro-shares/
+
+# Local Postgres data directory (mounted by compose.yml).
+.postgres-data/

--- a/apps/web/drizzle.config.ts
+++ b/apps/web/drizzle.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'drizzle-kit';
+
+/**
+ * Drizzle Kit config for migrations + studio. Reads `DATABASE_URL` from
+ * `apps/web/.env.local` (Next.js dev process picks it up automatically;
+ * `drizzle-kit` needs to be told via `dotenv` or env-cli when run
+ * standalone — current usage assumes the var is exported in the shell or
+ * sourced before `pnpm db:*` runs).
+ */
+export default defineConfig({
+  schema: './src/lib/db/schema.ts',
+  out: './drizzle',
+  dialect: 'postgresql',
+  dbCredentials: {
+    url: process.env['DATABASE_URL'] ?? '',
+  },
+  // Migrations are checked in; we don't want drizzle-kit to push schema
+  // changes implicitly. Always go through `db:generate` + review the SQL +
+  // `db:migrate` to apply.
+  strict: true,
+  verbose: true,
+});

--- a/apps/web/drizzle/0000_initial.sql
+++ b/apps/web/drizzle/0000_initial.sql
@@ -1,0 +1,17 @@
+CREATE TABLE "shares" (
+	"id" text PRIMARY KEY NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"schema_version" integer NOT NULL,
+	"messages" jsonb NOT NULL,
+	"spec" jsonb NOT NULL,
+	"parent_share_id" text
+);
+--> statement-breakpoint
+CREATE TABLE "conversations" (
+	"id" text PRIMARY KEY NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"title" text,
+	"messages" jsonb NOT NULL,
+	"spec" jsonb NOT NULL
+);

--- a/apps/web/drizzle/meta/0000_snapshot.json
+++ b/apps/web/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,120 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spec": {
+          "name": "spec",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shares": {
+      "name": "shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spec": {
+          "name": "spec",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_share_id": {
+          "name": "parent_share_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1746360000000,
+      "tag": "0000_initial",
+      "breakpoints": true
+    }
+  ]
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,11 @@
     "start": "next start",
     "typecheck": "tsc --noEmit",
     "check": "vp check",
-    "check:write": "vp check --fix"
+    "check:write": "vp check --fix",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate",
+    "db:studio": "drizzle-kit studio",
+    "migrate:from-fs": "tsx src/lib/db/migrate-from-fs.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "3.0.71",
@@ -20,7 +24,9 @@
     "@json-render/react": "catalog:",
     "@k8o/arte-odyssey": "catalog:",
     "ai": "6.0.168",
+    "drizzle-orm": "0.45.2",
     "next": "16.2.4",
+    "postgres": "3.4.9",
     "react": "catalog:",
     "react-dom": "catalog:",
     "shiki": "catalog:",
@@ -32,6 +38,8 @@
     "@types/node": "24.12.2",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
-    "postcss": "catalog:"
+    "drizzle-kit": "0.31.10",
+    "postcss": "catalog:",
+    "tsx": "4.21.0"
   }
 }

--- a/apps/web/src/app/api/conversations/[id]/events/route.ts
+++ b/apps/web/src/app/api/conversations/[id]/events/route.ts
@@ -1,0 +1,84 @@
+import { jsonError } from '../../../../../lib/api-response.ts';
+import { CONVERSATION_ID_PATTERN } from '../../../../../lib/conversation-types.ts';
+import { subscribe } from '../../../../../lib/job-store.ts';
+import {
+  type StreamEvent,
+  encodeStreamEvent,
+} from '../../../../../lib/stream-events.ts';
+
+type Params = Promise<{ id: string }>;
+
+/**
+ * SSE endpoint that delivers in-flight LLM stream events for a
+ * conversation (per ADR-016).
+ *
+ * The browser opens this with `EventSource('/api/conversations/<id>/events')`.
+ * Behavior:
+ *   - If a job is currently running for the conversation, the
+ *     subscriber receives any buffered text immediately (replay), then
+ *     live `chunk` events, then `done` (or `error`) when the job ends.
+ *   - If no job is running, the subscriber receives a single `done`
+ *     event right away. The browser's EventSource auto-reconnects, so
+ *     the client is responsible for closing the connection on `done`
+ *     to avoid an infinite reopen loop.
+ *
+ * No auth — same trust model as `/api/share` and `/api/generate` per
+ * ADR-013 ("self-hosted, trusted-network MVP").
+ */
+export const GET = async (_req: Request, { params }: { params: Params }) => {
+  const { id } = await params;
+  if (!CONVERSATION_ID_PATTERN.test(id)) {
+    return jsonError(404, 'Conversation not found');
+  }
+
+  let unsubscribe: (() => void) | null = null;
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const encoder = new TextEncoder();
+      const send = (event: StreamEvent) => {
+        try {
+          controller.enqueue(encoder.encode(encodeStreamEvent(event)));
+        } catch {
+          // Client closed the connection between events — nothing to do.
+        }
+        if (event.type === 'done' || event.type === 'error') {
+          // Close the stream so the browser stops auto-reconnecting.
+          // The job-store has already cleaned us up if this came from
+          // a real terminal event; if it was the synthetic `done` for
+          // an idle conversation the unsubscribe was already a noop.
+          try {
+            controller.close();
+          } catch {
+            // already closed
+          }
+          if (unsubscribe) {
+            unsubscribe();
+            unsubscribe = null;
+          }
+        }
+      };
+      unsubscribe = subscribe(id, send);
+    },
+    cancel() {
+      // Client (browser tab close, navigation away, hook cleanup) closed
+      // the stream first. Detach the subscriber so the job-store stops
+      // notifying us.
+      if (unsubscribe) {
+        unsubscribe();
+        unsubscribe = null;
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'content-type': 'text/event-stream; charset=utf-8',
+      // Disable proxy buffering so chunks reach the browser as they're
+      // emitted (relevant behind nginx; harmless elsewhere).
+      'cache-control': 'no-cache, no-transform',
+      connection: 'keep-alive',
+      'x-accel-buffering': 'no',
+    },
+  });
+};

--- a/apps/web/src/app/api/conversations/[id]/route.ts
+++ b/apps/web/src/app/api/conversations/[id]/route.ts
@@ -1,0 +1,88 @@
+import { jsonError } from '../../../../lib/api-response.ts';
+import {
+  deleteConversation,
+  getConversation,
+  updateConversation,
+} from '../../../../lib/conversation-store.ts';
+import { conversationInputSchema } from '../../../../lib/conversation-types.ts';
+
+type Params = Promise<{ id: string }>;
+
+/**
+ * GET /api/conversations/[id]
+ *
+ * Returns the full conversation record (messages + spec + title +
+ * timestamps). Used when the user picks a conversation from the sidebar
+ * and the chat needs to be re-seeded with its full state.
+ *
+ * Returns 404 for missing or invalid ids; the route does not distinguish
+ * "id format wrong" from "no such row" — both are equally "doesn't exist
+ * as far as the client is concerned."
+ */
+export const GET = async (_req: Request, { params }: { params: Params }) => {
+  const { id } = await params;
+  try {
+    const record = await getConversation(id);
+    if (!record) return jsonError(404, 'Conversation not found');
+    return Response.json(record);
+  } catch (err) {
+    return jsonError(
+      500,
+      err instanceof Error ? err.message : 'Failed to load conversation',
+    );
+  }
+};
+
+/**
+ * PATCH /api/conversations/[id]
+ *
+ * Overwrites the conversation's messages + spec + title. The chat hook
+ * sends the full state on every assistant turn — small payloads, no
+ * partial-update complexity, and the sidebar's `updated_at` ordering
+ * stays correct via the column bump in `updateConversation`.
+ */
+export const PATCH = async (req: Request, { params }: { params: Params }) => {
+  const { id } = await params;
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return jsonError(400, 'Request body must be valid JSON');
+  }
+  const parsed = conversationInputSchema.safeParse(raw);
+  if (!parsed.success) {
+    return jsonError(400, parsed.error.message);
+  }
+  try {
+    const ok = await updateConversation(id, parsed.data);
+    if (!ok) return jsonError(404, 'Conversation not found');
+    return new Response(null, { status: 204 });
+  } catch (err) {
+    return jsonError(
+      500,
+      err instanceof Error ? err.message : 'Failed to update conversation',
+    );
+  }
+};
+
+/**
+ * DELETE /api/conversations/[id]
+ *
+ * Removes the conversation row. There's no "soft delete" — the
+ * conversation is gone for everyone in the deployment. Matches the team
+ * trust model: the same person who can list conversations can also
+ * remove them.
+ */
+export const DELETE = async (_req: Request, { params }: { params: Params }) => {
+  const { id } = await params;
+  try {
+    const ok = await deleteConversation(id);
+    if (!ok) return jsonError(404, 'Conversation not found');
+    return new Response(null, { status: 204 });
+  } catch (err) {
+    return jsonError(
+      500,
+      err instanceof Error ? err.message : 'Failed to delete conversation',
+    );
+  }
+};

--- a/apps/web/src/app/api/conversations/active/route.ts
+++ b/apps/web/src/app/api/conversations/active/route.ts
@@ -1,0 +1,16 @@
+import { runningConversationIds } from '../../../../lib/job-store.ts';
+
+/**
+ * GET /api/conversations/active
+ *
+ * Returns the ids of conversations with an in-flight LLM job (per
+ * ADR-016). The sidebar polls this so the user can see which
+ * conversations are currently generating in the background — a
+ * teammate started something, or the operator's own previous turn is
+ * still running while they explore another conversation.
+ *
+ * Cheap: in-memory lookup, no DB hit. The sidebar polls at 2 s
+ * intervals; under that load this is essentially free.
+ */
+export const GET = () =>
+  Response.json({ conversationIds: runningConversationIds() });

--- a/apps/web/src/app/api/conversations/route.ts
+++ b/apps/web/src/app/api/conversations/route.ts
@@ -1,0 +1,65 @@
+import { jsonError } from '../../../lib/api-response.ts';
+import {
+  createConversation,
+  listConversations,
+} from '../../../lib/conversation-store.ts';
+import {
+  conversationInputSchema,
+  newConversationId,
+} from '../../../lib/conversation-types.ts';
+
+/**
+ * GET /api/conversations
+ *
+ * Returns the lightweight summary list for the sidebar (id + derived
+ * title + timestamps). Newest-updated first.
+ *
+ * No auth — same trust model as `/api/share` and `/api/generate` per
+ * ADR-013 ("self-hosted, trusted-network MVP"). Anyone reaching the
+ * server sees every conversation, by design.
+ */
+export const GET = async () => {
+  try {
+    const summaries = await listConversations();
+    return Response.json({ conversations: summaries });
+  } catch (err) {
+    return jsonError(
+      500,
+      err instanceof Error ? err.message : 'Failed to list conversations',
+    );
+  }
+};
+
+/**
+ * POST /api/conversations
+ *
+ * Creates a new conversation row from the supplied messages + spec. Used
+ * when the chat hook reaches the end of its first stream and needs to
+ * persist the result, and when "Continue this conversation" forks a
+ * shared snapshot into a fresh conversation.
+ */
+export const POST = async (req: Request) => {
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return jsonError(400, 'Request body must be valid JSON');
+  }
+
+  const parsed = conversationInputSchema.safeParse(raw);
+  if (!parsed.success) {
+    return jsonError(400, parsed.error.message);
+  }
+
+  const id = newConversationId();
+  try {
+    await createConversation(id, parsed.data);
+  } catch (err) {
+    return jsonError(
+      500,
+      err instanceof Error ? err.message : 'Failed to create conversation',
+    );
+  }
+
+  return Response.json({ id }, { status: 201 });
+};

--- a/apps/web/src/app/api/generate/route.ts
+++ b/apps/web/src/app/api/generate/route.ts
@@ -1,117 +1,62 @@
-import { createModel } from '@decoro/llm-config';
-import { type Spec, buildUserPrompt } from '@json-render/core';
-import { type ModelMessage, streamText } from 'ai';
 import { z } from 'zod';
 
-import { adapter, llm } from '../../../../decoro.config.ts';
 import { jsonError } from '../../../lib/api-response.ts';
+import { chatMessageSchema } from '../../../lib/chat-types.ts';
 import {
-  MAX_MESSAGE_CHARS,
-  MAX_MESSAGES,
-  specSchema,
-  toSpec,
-} from '../../../lib/spec-schema.ts';
-
-// `messageSchema` shape is local to this route — the LLM API takes
-// `{role, content}` with a `system` role; the chat / share path uses
-// `{id, role, text}` (see share-types.ts). Same per-message char limit.
-const messageSchema = z.object({
-  role: z.enum(['user', 'assistant', 'system']),
-  content: z.string().min(1).max(MAX_MESSAGE_CHARS),
-});
+  createConversation,
+  getConversation,
+  updateConversation,
+} from '../../../lib/conversation-store.ts';
+import {
+  CONVERSATION_ID_PATTERN,
+  newConversationId,
+} from '../../../lib/conversation-types.ts';
+import { startGenerateJob } from '../../../lib/generate-job.ts';
+import { MAX_MESSAGES, specSchema, toSpec } from '../../../lib/spec-schema.ts';
 
 const requestSchema = z.object({
-  messages: z.array(messageSchema).min(1).max(MAX_MESSAGES),
-  currentSpec: specSchema.nullable().optional(),
+  /**
+   * `null` / omitted on the first turn of a fresh chat. Otherwise, the
+   * id of the conversation row this turn should attach to. Forks from a
+   * shared snapshot also start with `null` — the first send mints a new
+   * row, leaving the source share immutable.
+   */
+  conversationId: z
+    .string()
+    .regex(CONVERSATION_ID_PATTERN)
+    .nullable()
+    .optional(),
+  /**
+   * Full conversation messages including the user message that just got
+   * typed. Server-side, the last user message is rewritten via
+   * `buildUserPrompt` so the LLM receives the current spec as edit
+   * context (M8 iteration loop).
+   */
+  messages: z.array(chatMessageSchema).min(1).max(MAX_MESSAGES),
+  /**
+   * Spec the user is iterating ON. Empty (`{ root: '', elements: {} }`)
+   * for the first turn; otherwise the result of the previous turn. Used
+   * both for `buildUserPrompt` context and as the persisted `spec` on
+   * the conversation row when this is a fresh create.
+   */
+  spec: specSchema,
 });
 
-// Ask the model to prefix the JSONL stream with a single short natural-
-// language line summarizing what it's building. The chat pane surfaces this
-// line back to the user as the assistant's "answer" — without it, the only
-// visible feedback is the rendered preview, which feels mute mid-stream.
-// `createMixedStreamParser` already distinguishes JSONL patch lines from
-// prose, so the extra line lands in `onText` without disturbing patches.
-const responsePreambleInstruction = [
-  'Response format (STRICT — the chat UI parses prose vs JSON by line):',
-  '- Line 1: exactly ONE short sentence (≤ 15 words) describing what you are building or changing in this turn. Plain prose, no JSON, no leading whitespace.',
-  '- Line 1 MUST end with a literal newline character before any JSON appears. Do not place JSON on the same line as the sentence.',
-  '- Lines 2+: JSONL patch lines, one complete JSON object per line. No prose between or after the patches.',
-  '- Example shape:',
-  '    Adding a primary submit button.\\n',
-  '    {"op":"add","path":"/elements/btn","value":{"type":"Button","props":{"label":"Save"},"children":[]}}\\n',
-  '    {"op":"replace","path":"/root","value":"btn"}\\n',
-].join('\n');
-
-// Universal spec discipline. Applies to every adapter — these are
-// constraints of the json-render spec model and the catalog contract,
-// not of any specific design system. The codegen also strips unknown
-// props as belt-and-braces, but reminding the model up front is cheaper
-// than repairing the spec downstream.
-const specDisciplineInstruction = [
-  'Spec discipline:',
-  '- Set only the props each component declares in its catalog entry. Unknown props are silently dropped by codegen.',
-  '- `children` is an array of OTHER element keys, not raw strings. To place literal text, use whatever text primitive the catalog provides (look for an entry like `Text`, or a `text` / `label` / `content` prop on the component itself).',
-  '- If a parent has nothing to say, omit the child — do NOT insert an empty placeholder element.',
-  '- Use ONLY components, props, and enum values that appear in the catalog. Do NOT invent component names, icon names, or option values from libraries the catalog does not list (Material Symbols, Heroicons, MUI, etc.) — they will not resolve and the preview will render raw text or an empty slot.',
-].join('\n');
-
-// Decoro is a design tool — users want to *see* their UI, not run it. The
-// LLM's first instinct is to produce a state-bound interactive prototype
-// (e.g. a chat with `$bindEach: '/messages'` over the message list, or
-// `$cond` for sender-side bubble styling). With state empty, the preview
-// renders nothing — the user complains "the UI hasn't changed", because
-// it literally hasn't: the template is correct, the data is missing.
-//
-// Default to mockup-first generation. The user can opt into interactive
-// behavior by asking explicitly.
-const mockupFirstInstruction = [
-  'Mockup-first generation:',
-  '- Decoro is a design tool. Users want to SEE the UI populated, not wire up state.',
-  '- Prefer STATIC content baked directly into the spec. Render 2–4 example items inline for chat / list / table / feed UIs so the preview is populated the moment generation finishes.',
-  '- AVOID `$bindEach`, `$bindState`, `$cond`, `$item`, and action bindings (`pushState`, etc.) by default. They produce templates that render empty without state initialization.',
-  '- For form UIs, leave inputs empty (the user fills them); for display UIs, show concrete example values directly in `props`.',
-  '- Only use state bindings / actions when the user EXPLICITLY asks for an interactive prototype.',
-].join('\n');
-
-// Order matters. Catalog first (the model needs to know what exists),
-// then library context (philosophy + library-specific gotchas from the
-// adapter), then universal Decoro rules (spec discipline, mockup-first,
-// response format). Library-specific guidance comes from
-// `adapter.metadata.promptGuidance` so adapter authors can tell the LLM
-// about THEIR library's quirks without touching this route.
-const systemPrompt = [
-  adapter.catalog.prompt({ mode: 'standalone' }),
-  '',
-  'Library design principles:',
-  adapter.metadata.designPrinciples,
-  ...(adapter.metadata.promptGuidance === undefined
-    ? []
-    : ['', adapter.metadata.promptGuidance]),
-  '',
-  specDisciplineInstruction,
-  '',
-  mockupFirstInstruction,
-  '',
-  responsePreambleInstruction,
-].join('\n');
-
-const isMeaningfulSpec = (spec: Spec | null | undefined): spec is Spec =>
-  spec !== null && spec !== undefined && spec.root !== '';
-
 /**
- * POST /api/generate streams the LLM's raw text output back to the client.
+ * POST /api/generate kicks off an LLM stream **on the server** and
+ * returns immediately with the conversationId. The actual stream lives
+ * in the in-memory job store keyed by conversationId; clients subscribe
+ * to it via `GET /api/conversations/[id]/events` (SSE). See ADR-016.
  *
- * The system prompt (built by `catalog.prompt({ mode: 'standalone' })`)
- * instructs the model to emit json-render JSON patches one per line, which
- * the client's `useDecoroChat` hook consumes via `createMixedStreamParser`.
- *
- * For iteration: when `currentSpec` is supplied and non-empty, the last user
- * message is rewritten through `buildUserPrompt` so it includes the current
- * spec as edit context. Earlier messages stay verbatim.
- *
- * Input is validated with zod and capped (messages count / per-message
- * length / spec element count) so a runaway client cannot DoS the endpoint
- * or rack up an unbounded LLM bill.
+ * Flow:
+ *   1. Validate the request, then mint or look up the conversation row.
+ *      Brand-new conversations get persisted with the user message
+ *      immediately so the URL can update before the LLM responds.
+ *   2. `startGenerateJob` cancels any previous job for this
+ *      conversation, spawns the background `streamText`, and PATCHes
+ *      the row on completion.
+ *   3. Return `{ conversationId }`. The browser opens (or has already
+ *      opened) the SSE channel and receives the stream there.
  */
 export const POST = async (req: Request) => {
   let raw: unknown;
@@ -126,40 +71,48 @@ export const POST = async (req: Request) => {
     return jsonError(400, parsed.error.message);
   }
 
-  const currentSpec = parsed.data.currentSpec
-    ? toSpec(parsed.data.currentSpec)
-    : null;
-  const augmented = augmentLastUserMessage(parsed.data.messages, currentSpec);
+  const inputSpec = toSpec(parsed.data.spec);
+  const inputMessages = parsed.data.messages;
 
-  try {
-    const result = streamText({
-      model: createModel(llm),
-      system: systemPrompt,
-      messages: augmented,
+  let conversationId: string;
+  if (
+    parsed.data.conversationId === undefined ||
+    parsed.data.conversationId === null
+  ) {
+    conversationId = newConversationId();
+    try {
+      await createConversation(conversationId, {
+        messages: inputMessages,
+        spec: parsed.data.spec,
+      });
+    } catch (err) {
+      return jsonError(
+        500,
+        err instanceof Error ? err.message : 'Failed to create conversation',
+      );
+    }
+  } else {
+    ({ conversationId } = parsed.data);
+    const existing = await getConversation(conversationId);
+    if (!existing) {
+      return jsonError(404, 'Conversation not found');
+    }
+    // Persist the new user message + current spec immediately so any
+    // mid-stream subscriber that fetches conversation state sees it
+    // before the assistant turn lands. The post-stream PATCH inside
+    // `startGenerateJob` overwrites with the full state once the LLM
+    // finishes.
+    await updateConversation(conversationId, {
+      messages: inputMessages,
+      spec: parsed.data.spec,
     });
-    return result.toTextStreamResponse();
-  } catch (err) {
-    return jsonError(
-      500,
-      err instanceof Error ? err.message : 'Failed to start generation',
-    );
   }
-};
 
-const augmentLastUserMessage = (
-  messages: ModelMessage[],
-  currentSpec: Spec | null | undefined,
-): ModelMessage[] => {
-  const lastIdx = messages.length - 1;
-  return messages.map((msg, idx) => {
-    if (idx !== lastIdx || msg.role !== 'user') return msg;
-    if (typeof msg.content !== 'string') return msg;
-    return {
-      ...msg,
-      content: buildUserPrompt({
-        prompt: msg.content,
-        currentSpec: isMeaningfulSpec(currentSpec) ? currentSpec : undefined,
-      }),
-    };
+  startGenerateJob({
+    conversationId,
+    seedMessages: inputMessages,
+    seedSpec: inputSpec,
   });
+
+  return Response.json({ conversationId });
 };

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,8 +1,20 @@
+import { Suspense } from 'react';
+
 import { adapter } from '../../decoro.config.ts';
 import { HomeShell } from '../components/home-shell.tsx';
 
+// HomeShell uses `useSearchParams` to read `?conversation=` and
+// `?from=`, which forces a client-side bailout during static
+// generation. The Suspense boundary is what tells Next.js to render
+// the fallback during prerender and hydrate the search-params-aware
+// shell on the client. Without it, `next build` fails with
+// "useSearchParams() should be wrapped in a suspense boundary."
 const HomePage = () => (
-  <HomeShell tagline={`AI UI generation for ${adapter.metadata.displayName}`} />
+  <Suspense fallback={null}>
+    <HomeShell
+      tagline={`AI UI generation for ${adapter.metadata.displayName}`}
+    />
+  </Suspense>
 );
 
 export default HomePage;

--- a/apps/web/src/app/preview/page.tsx
+++ b/apps/web/src/app/preview/page.tsx
@@ -7,7 +7,8 @@ import { useEffect, useState } from 'react';
 
 import { adapter } from '../../../decoro.config.ts';
 import {
-  type PreviewOutboundMessage,
+  PREVIEW_CHANNEL,
+  type PreviewReadyMessage,
   isPreviewMessage,
 } from '../../lib/preview-message.ts';
 
@@ -15,21 +16,26 @@ const PreviewPage = () => {
   const [spec, setSpec] = useState<Spec | null>(null);
 
   useEffect(() => {
+    const channel = new BroadcastChannel(PREVIEW_CHANNEL);
     const handler = (event: MessageEvent) => {
-      // Origin check alone lets any same-origin window impersonate the
-      // parent. Pin acceptance to the actual parent Window.
-      if (event.source !== window.parent) return;
-      if (event.origin !== window.location.origin) return;
       if (!isPreviewMessage(event.data)) return;
       if (event.data.type === 'decoro:spec') setSpec(event.data.spec);
     };
-    window.addEventListener('message', handler);
+    channel.addEventListener('message', handler);
 
-    const ready: PreviewOutboundMessage = { type: 'decoro:ready' };
-    window.parent.postMessage(ready, window.location.origin);
+    // Ask the publisher (the main app) to (re-)broadcast the current spec.
+    // Used both on first mount of the embedded iframe and on first mount
+    // of any popped-out preview window — neither should have to wait for
+    // the next user action to populate.
+    const ready: PreviewReadyMessage = { type: 'decoro:ready' };
+    // BroadcastChannel.postMessage takes only the message; the lint
+    // rule's targetOrigin requirement applies to window.postMessage.
+    // oxlint-disable-next-line eslint-plugin-unicorn(require-post-message-target-origin)
+    channel.postMessage(ready);
 
     return () => {
-      window.removeEventListener('message', handler);
+      channel.removeEventListener('message', handler);
+      channel.close();
     };
   }, []);
 

--- a/apps/web/src/components/conversations-sidebar.tsx
+++ b/apps/web/src/components/conversations-sidebar.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { CloseIcon, IconButton, PlusIcon, Spinner } from '@k8o/arte-odyssey';
+import { useCallback, useEffect, useState } from 'react';
+
+import type { ConversationSummary } from '../lib/conversation-types.ts';
+
+type Props = {
+  activeId: string | null;
+  onPickConversation: (id: string) => void;
+  onNewConversation: () => void;
+};
+
+type LoadState =
+  | { kind: 'loading' }
+  | { kind: 'ok'; conversations: ConversationSummary[] }
+  | { kind: 'error'; message: string };
+
+/**
+ * Persistent left rail showing the team's conversation history.
+ *
+ * The list re-fetches on mount, when the active id changes (the parent
+ * just persisted a turn), and when the user deletes a row. There's no
+ * websocket / SSE-based live update: the sidebar reflects what THIS
+ * browser has done, plus whatever was on disk at last fetch.
+ *
+ * Failing requests don't take the chat down with them — the sidebar
+ * shows an inline error and the chat keeps running.
+ */
+export const ConversationsSidebar = ({
+  activeId,
+  onPickConversation,
+  onNewConversation,
+}: Props) => {
+  const [state, setState] = useState<LoadState>({ kind: 'loading' });
+
+  const refresh = useCallback(async () => {
+    setState({ kind: 'loading' });
+    try {
+      const res = await fetch('/api/conversations');
+      if (!res.ok) throw new Error(`HTTP ${res.status.toString()}`);
+      const data = (await res.json()) as {
+        conversations: ConversationSummary[];
+      };
+      setState({ kind: 'ok', conversations: data.conversations });
+    } catch (err) {
+      setState({
+        kind: 'error',
+        message: err instanceof Error ? err.message : 'Failed to load',
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh, activeId]);
+
+  const onDelete = useCallback(
+    async (id: string) => {
+      // Native confirm — we deliberately keep destructive interactions
+      // chunky so a stray click can't blow away a teammate's work.
+      const ok = window.confirm(
+        'Delete this conversation? This cannot be undone.',
+      );
+      if (!ok) return;
+      try {
+        const res = await fetch(`/api/conversations/${id}`, {
+          method: 'DELETE',
+        });
+        if (!res.ok && res.status !== 404) {
+          throw new Error(`HTTP ${res.status.toString()}`);
+        }
+        if (id === activeId) onNewConversation();
+        await refresh();
+      } catch (err) {
+        setState({
+          kind: 'error',
+          message: err instanceof Error ? err.message : 'Delete failed',
+        });
+      }
+    },
+    [activeId, onNewConversation, refresh],
+  );
+
+  return (
+    <aside className="bg-bg-base flex h-full w-64 flex-col overflow-hidden rounded-xl shadow-sm">
+      <div className="border-border-subtle flex items-center justify-between gap-2 border-b px-4 py-3">
+        <h2 className="text-fg-base text-sm font-medium">Conversations</h2>
+        <IconButton
+          label="New conversation"
+          size="sm"
+          bg="transparent"
+          onAction={onNewConversation}
+        >
+          <PlusIcon size="sm" />
+        </IconButton>
+      </div>
+      <div className="flex-1 overflow-y-auto px-2 py-2">
+        {state.kind === 'loading' ? (
+          <div className="flex items-center justify-center py-6">
+            <Spinner size="sm" />
+          </div>
+        ) : state.kind === 'error' ? (
+          <p className="text-fg-mute px-2 py-2 text-xs" role="alert">
+            {state.message}
+          </p>
+        ) : state.conversations.length === 0 ? (
+          <p className="text-fg-mute px-2 py-2 text-xs">
+            No saved conversations yet.
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-0.5">
+            {state.conversations.map((c) => {
+              const isActive = c.id === activeId;
+              return (
+                <li key={c.id} className="group/row relative">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onPickConversation(c.id);
+                    }}
+                    className={`block w-full rounded-md px-3 py-2 pr-8 text-left text-sm ${
+                      isActive
+                        ? 'bg-bg-subtle text-fg-base'
+                        : 'text-fg-base hover:bg-bg-subtle/60'
+                    }`}
+                  >
+                    <span className="line-clamp-2 break-words">{c.title}</span>
+                  </button>
+                  <span className="absolute top-1 right-1 opacity-0 group-hover/row:opacity-100">
+                    <IconButton
+                      label="Delete conversation"
+                      size="sm"
+                      bg="transparent"
+                      onAction={() => {
+                        void onDelete(c.id);
+                      }}
+                    >
+                      <CloseIcon size="sm" />
+                    </IconButton>
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </aside>
+  );
+};

--- a/apps/web/src/components/conversations-sidebar.tsx
+++ b/apps/web/src/components/conversations-sidebar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { CloseIcon, IconButton, PlusIcon, Spinner } from '@k8o/arte-odyssey';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import type { ConversationSummary } from '../lib/conversation-types.ts';
 
@@ -27,12 +27,15 @@ type LoadState =
  * Failing requests don't take the chat down with them — the sidebar
  * shows an inline error and the chat keeps running.
  */
+const ACTIVE_POLL_INTERVAL_MS = 2000;
+
 export const ConversationsSidebar = ({
   activeId,
   onPickConversation,
   onNewConversation,
 }: Props) => {
   const [state, setState] = useState<LoadState>({ kind: 'loading' });
+  const [activeJobs, setActiveJobs] = useState<ReadonlySet<string>>(new Set());
 
   const refresh = useCallback(async () => {
     setState({ kind: 'loading' });
@@ -54,6 +57,46 @@ export const ConversationsSidebar = ({
   useEffect(() => {
     void refresh();
   }, [refresh, activeId]);
+
+  // Poll the active-jobs endpoint so the sidebar shows a spinner on
+  // any conversation currently generating in the background — including
+  // ones the operator isn't looking at right now (a turn started
+  // pre-navigation, or a teammate's in-flight stream). Cheap: in-memory
+  // lookup, no DB hit per poll.
+  useEffect(() => {
+    let cancelled = false;
+    const poll = async () => {
+      try {
+        const res = await fetch('/api/conversations/active');
+        if (!res.ok) return;
+        const data = (await res.json()) as { conversationIds: string[] };
+        if (cancelled) return;
+        setActiveJobs(new Set(data.conversationIds));
+      } catch {
+        // Silent — the spinner not appearing is a reasonable failure.
+      }
+    };
+    void poll();
+    const handle = setInterval(() => {
+      void poll();
+    }, ACTIVE_POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(handle);
+    };
+  }, []);
+
+  // Refresh the conversation list whenever a job finishes (an id
+  // disappeared from the active set). Newly-completed conversations
+  // need their title / updated_at re-pulled so the sidebar rises to
+  // the top.
+  const previousActiveRef = useRef<ReadonlySet<string>>(activeJobs);
+  useEffect(() => {
+    const prev = previousActiveRef.current;
+    const completed = [...prev].some((id) => !activeJobs.has(id));
+    if (completed) void refresh();
+    previousActiveRef.current = activeJobs;
+  }, [activeJobs, refresh]);
 
   const onDelete = useCallback(
     async (id: string) => {
@@ -112,6 +155,7 @@ export const ConversationsSidebar = ({
           <ul className="flex flex-col gap-0.5">
             {state.conversations.map((c) => {
               const isActive = c.id === activeId;
+              const isGenerating = activeJobs.has(c.id);
               return (
                 <li key={c.id} className="group/row relative">
                   <button
@@ -125,7 +169,20 @@ export const ConversationsSidebar = ({
                         : 'text-fg-base hover:bg-bg-subtle/60'
                     }`}
                   >
-                    <span className="line-clamp-2 break-words">{c.title}</span>
+                    <span className="flex items-start gap-2">
+                      {isGenerating ? (
+                        <span
+                          className="text-fg-mute mt-0.5 shrink-0"
+                          aria-label="Generating"
+                          title="Generating"
+                        >
+                          <Spinner size="sm" />
+                        </span>
+                      ) : null}
+                      <span className="line-clamp-2 break-words">
+                        {c.title}
+                      </span>
+                    </span>
                   </button>
                   <span className="absolute top-1 right-1 opacity-0 group-hover/row:opacity-100">
                     <IconButton

--- a/apps/web/src/components/home-shell.tsx
+++ b/apps/web/src/components/home-shell.tsx
@@ -1,103 +1,118 @@
 'use client';
 
-import { ViewIcon } from '@k8o/arte-odyssey';
-import { useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
 
-import type { ChatMessage } from '../lib/chat-types.ts';
-import { useDecoroChat } from '../lib/use-decoro-chat.ts';
+import type { ConversationRecord } from '../lib/conversation-types.ts';
+import type { SnapshotRecord } from '../lib/share-types.ts';
+import { toSpec } from '../lib/spec-schema.ts';
 import { AppHeader } from './app-header.tsx';
-import { ChatPane } from './chat-pane.tsx';
-import { CodePanel } from './code-panel.tsx';
-import { PreviewFrame } from './preview-frame.tsx';
-import { ShareButton } from './share-button.tsx';
-import {
-  CodeBracketsIcon,
-  type TabItem,
-  TabSwitcher,
-} from './tab-switcher.tsx';
+import { ConversationsSidebar } from './conversations-sidebar.tsx';
+import { HomeWorkspace, type WorkspaceSeed } from './home-workspace.tsx';
 
-type OutputTab = 'preview' | 'code';
+type Seed = WorkspaceSeed & {
+  /** React key — bumping it remounts the workspace so the chat hook re-seeds. */
+  key: string;
+};
 
-const OUTPUT_TABS: ReadonlyArray<TabItem<OutputTab>> = [
-  { id: 'preview', label: 'Preview', icon: <ViewIcon size="sm" /> },
-  { id: 'code', label: 'Code', icon: <CodeBracketsIcon /> },
-];
+const FRESH_SEED: Seed = {
+  key: 'fresh',
+  initialState: null,
+  conversationId: null,
+};
 
-/**
- * Top-level client shell for `/`. Wires the chat pane to `useDecoroChat`,
- * which posts `{ messages, currentSpec }` to /api/generate so each follow-up
- * iterates on the existing spec instead of regenerating from scratch (M8).
- *
- * The right pane shows Preview and Code as tabs. Both are kept mounted via
- * `hidden` so the iframe's spec / postMessage handshake survives tab switches.
- */
 type Props = {
   /**
    * Header tagline. Built by the server-side page from
    * `adapter.metadata.displayName` so this client component doesn't need
-   * to import the adapter binding (which would push it over the
-   * max-dependencies lint).
+   * to import the adapter binding.
    */
   tagline: string;
 };
 
+/**
+ * Top-level client shell for `/`. Owns the seed state for the chat
+ * workspace (which conversation is loaded, or whether we're forking from
+ * a share) and the conversation sidebar; delegates the actual chat /
+ * preview / code rendering to `<HomeWorkspace />` so swapping seeds is
+ * just a key bump.
+ */
 export const HomeShell = ({ tagline }: Props) => {
-  const { messages, spec, isStreaming, error, send } = useDecoroChat({
-    api: '/api/generate',
-  });
-  const [tab, setTab] = useState<OutputTab>('preview');
+  const searchParams = useSearchParams();
+  const fromShareId = searchParams.get('from');
 
-  const chatMessages: ChatMessage[] = messages.map((m) => ({
-    id: m.id,
-    role: m.role,
-    text: m.text,
-  }));
+  const [seed, setSeed] = useState<Seed>(FRESH_SEED);
+
+  useEffect(() => {
+    if (fromShareId === null || fromShareId === '') {
+      return undefined;
+    }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch(`/api/share/${fromShareId}`);
+        if (!res.ok) return;
+        const snapshot = (await res.json()) as SnapshotRecord;
+        // Cleanup may flip `cancelled` while the await is in flight; lint
+        // narrows the literal `false` initializer and can't see that.
+        // oxlint-disable-next-line typescript-eslint(no-unnecessary-condition)
+        if (cancelled) return;
+        setSeed({
+          key: `from-share-${fromShareId}`,
+          initialState: {
+            messages: snapshot.messages,
+            spec: toSpec(snapshot.spec),
+          },
+          // Forks deliberately do NOT inherit a conversation id — the
+          // first save mints a new conversation row, leaving the source
+          // share immutable.
+          conversationId: null,
+        });
+      } catch {
+        // Ignore failures; the user just sees a fresh workspace.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [fromShareId]);
+
+  const handlePickConversation = (id: string) => {
+    void (async () => {
+      try {
+        const res = await fetch(`/api/conversations/${id}`);
+        if (!res.ok) return;
+        const record = (await res.json()) as ConversationRecord;
+        setSeed({
+          key: `convo-${id}`,
+          initialState: {
+            messages: record.messages,
+            spec: toSpec(record.spec),
+          },
+          conversationId: record.id,
+        });
+      } catch {
+        // Ignore — sidebar's error path will show on next refresh.
+      }
+    })();
+  };
+
+  const handleNewConversation = () => {
+    setSeed({ ...FRESH_SEED, key: `fresh-${Date.now().toString()}` });
+  };
 
   return (
     <div className="bg-bg-surface text-fg-base flex h-dvh flex-col">
-      <AppHeader
-        tagline={tagline}
-        rightSlot={
-          <ShareButton
-            spec={spec}
-            messages={chatMessages}
-            isStreaming={isStreaming}
-          />
-        }
-      />
+      <AppHeader tagline={tagline} />
       <main className="flex flex-1 gap-4 overflow-hidden p-4">
-        <section
-          aria-label="Chat"
-          className="bg-bg-base flex w-5/12 flex-col overflow-hidden rounded-xl shadow-sm"
-        >
-          <ChatPane
-            messages={chatMessages}
-            isStreaming={isStreaming}
-            error={error}
-            onSubmit={(prompt) => {
-              void send(prompt);
-            }}
-          />
-        </section>
-        <section
-          aria-label="Output"
-          className="bg-bg-base flex w-7/12 flex-col overflow-hidden rounded-xl shadow-sm"
-        >
-          <TabSwitcher
-            ariaLabel="Output"
-            tabs={OUTPUT_TABS}
-            value={tab}
-            onChange={setTab}
-          />
-          <div className="relative flex-1 overflow-hidden">
-            <div hidden={tab !== 'preview'} className="h-full">
-              <PreviewFrame spec={spec} />
-            </div>
-            <div hidden={tab !== 'code'} className="h-full overflow-auto">
-              <CodePanel spec={spec} />
-            </div>
-          </div>
-        </section>
+        <ConversationsSidebar
+          activeId={seed.conversationId}
+          onPickConversation={handlePickConversation}
+          onNewConversation={handleNewConversation}
+        />
+        <div className="flex flex-1 gap-4 overflow-hidden">
+          <HomeWorkspace key={seed.key} seed={seed} />
+        </div>
       </main>
     </div>
   );

--- a/apps/web/src/components/home-shell.tsx
+++ b/apps/web/src/components/home-shell.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import type { ConversationRecord } from '../lib/conversation-types.ts';
 import type { SnapshotRecord } from '../lib/share-types.ts';
@@ -53,10 +53,24 @@ export const HomeShell = ({ tagline }: Props) => {
   const conversationParam = searchParams.get('conversation');
 
   const [seed, setSeed] = useState<Seed>(FRESH_SEED);
+  // Latest active conversation id seen in render — used to short-circuit
+  // the resume effect when a URL change came from `router.replace` we
+  // ourselves issued (e.g. after the chat hook minted a row up front).
+  // Without this, the URL change would fire the resume effect, re-fetch
+  // the freshly-created (still single-message) row, and clobber the
+  // in-progress chat.
+  const activeConversationIdRef = useRef<string | null>(seed.conversationId);
+  activeConversationIdRef.current = seed.conversationId;
 
   // Resume an existing conversation when the URL points at one.
   useEffect(() => {
     if (conversationParam === null || conversationParam === '') {
+      return undefined;
+    }
+    if (activeConversationIdRef.current === conversationParam) {
+      // We already have this conversation loaded (most commonly: the
+      // chat hook just created the row and bumped the URL). No re-fetch
+      // needed.
       return undefined;
     }
     let cancelled = false;
@@ -136,10 +150,13 @@ export const HomeShell = ({ tagline }: Props) => {
 
   const handleConversationCreated = useCallback(
     (id: string) => {
-      // The chat hook just persisted a brand-new row. Reflect it in the
-      // URL so refresh / bookmark / share-link works. `replace` (not
-      // `push`) so the browser back stack doesn't pile up an entry per
-      // conversation start.
+      // The chat hook just persisted a brand-new row. Two things have to
+      // happen: reflect the id in the URL (so refresh / bookmark / share
+      // works), AND update `seed.conversationId` so the resume effect
+      // sees the URL change as one we initiated and skips the re-fetch
+      // that would clobber the in-progress chat. Same key — we do NOT
+      // want HomeWorkspace to remount.
+      setSeed((prev) => ({ ...prev, conversationId: id }));
       router.replace(`/?conversation=${id}`);
     },
     [router],

--- a/apps/web/src/components/home-shell.tsx
+++ b/apps/web/src/components/home-shell.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useSearchParams } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useCallback, useEffect, useState } from 'react';
 
 import type { ConversationRecord } from '../lib/conversation-types.ts';
 import type { SnapshotRecord } from '../lib/share-types.ts';
@@ -36,14 +36,61 @@ type Props = {
  * a share) and the conversation sidebar; delegates the actual chat /
  * preview / code rendering to `<HomeWorkspace />` so swapping seeds is
  * just a key bump.
+ *
+ * URL is the source of truth for which conversation is active:
+ * - `/` → fresh chat
+ * - `/?conversation=<id>` → resume conversation `<id>`
+ * - `/?from=<shareId>` → fork from share `<shareId>` (becomes
+ *   `/?conversation=<newId>` after the first save mints a row)
+ *
+ * That makes refresh, browser back, and bookmarking behave the way
+ * users expect.
  */
 export const HomeShell = ({ tagline }: Props) => {
+  const router = useRouter();
   const searchParams = useSearchParams();
   const fromShareId = searchParams.get('from');
+  const conversationParam = searchParams.get('conversation');
 
   const [seed, setSeed] = useState<Seed>(FRESH_SEED);
 
+  // Resume an existing conversation when the URL points at one.
   useEffect(() => {
+    if (conversationParam === null || conversationParam === '') {
+      return undefined;
+    }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch(`/api/conversations/${conversationParam}`);
+        if (!res.ok) return;
+        const record = (await res.json()) as ConversationRecord;
+        // oxlint-disable-next-line typescript-eslint(no-unnecessary-condition)
+        if (cancelled) return;
+        setSeed({
+          key: `convo-${conversationParam}`,
+          initialState: {
+            messages: record.messages,
+            spec: toSpec(record.spec),
+          },
+          conversationId: record.id,
+        });
+      } catch {
+        // Ignore failures; the user just sees a fresh workspace.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [conversationParam]);
+
+  // Fork from a share — `?from=<shareId>` seeds a brand-new conversation.
+  // `?conversation=` takes precedence over `?from=` so a saved fork's URL
+  // resolves to the conversation, not the original share.
+  useEffect(() => {
+    if (conversationParam !== null && conversationParam !== '') {
+      return undefined;
+    }
     if (fromShareId === null || fromShareId === '') {
       return undefined;
     }
@@ -53,8 +100,6 @@ export const HomeShell = ({ tagline }: Props) => {
         const res = await fetch(`/api/share/${fromShareId}`);
         if (!res.ok) return;
         const snapshot = (await res.json()) as SnapshotRecord;
-        // Cleanup may flip `cancelled` while the await is in flight; lint
-        // narrows the literal `false` initializer and can't see that.
         // oxlint-disable-next-line typescript-eslint(no-unnecessary-condition)
         if (cancelled) return;
         setSeed({
@@ -75,31 +120,30 @@ export const HomeShell = ({ tagline }: Props) => {
     return () => {
       cancelled = true;
     };
-  }, [fromShareId]);
+  }, [conversationParam, fromShareId]);
 
-  const handlePickConversation = (id: string) => {
-    void (async () => {
-      try {
-        const res = await fetch(`/api/conversations/${id}`);
-        if (!res.ok) return;
-        const record = (await res.json()) as ConversationRecord;
-        setSeed({
-          key: `convo-${id}`,
-          initialState: {
-            messages: record.messages,
-            spec: toSpec(record.spec),
-          },
-          conversationId: record.id,
-        });
-      } catch {
-        // Ignore — sidebar's error path will show on next refresh.
-      }
-    })();
-  };
+  const handlePickConversation = useCallback(
+    (id: string) => {
+      router.replace(`/?conversation=${id}`);
+    },
+    [router],
+  );
 
-  const handleNewConversation = () => {
+  const handleNewConversation = useCallback(() => {
     setSeed({ ...FRESH_SEED, key: `fresh-${Date.now().toString()}` });
-  };
+    router.replace('/');
+  }, [router]);
+
+  const handleConversationCreated = useCallback(
+    (id: string) => {
+      // The chat hook just persisted a brand-new row. Reflect it in the
+      // URL so refresh / bookmark / share-link works. `replace` (not
+      // `push`) so the browser back stack doesn't pile up an entry per
+      // conversation start.
+      router.replace(`/?conversation=${id}`);
+    },
+    [router],
+  );
 
   return (
     <div className="bg-bg-surface text-fg-base flex h-dvh flex-col">
@@ -111,7 +155,11 @@ export const HomeShell = ({ tagline }: Props) => {
           onNewConversation={handleNewConversation}
         />
         <div className="flex flex-1 gap-4 overflow-hidden">
-          <HomeWorkspace key={seed.key} seed={seed} />
+          <HomeWorkspace
+            key={seed.key}
+            seed={seed}
+            onConversationCreated={handleConversationCreated}
+          />
         </div>
       </main>
     </div>

--- a/apps/web/src/components/home-workspace.tsx
+++ b/apps/web/src/components/home-workspace.tsx
@@ -1,28 +1,12 @@
 'use client';
 
 import type { Spec } from '@json-render/core';
-import { ViewIcon } from '@k8o/arte-odyssey';
-import { useState } from 'react';
 
 import type { ChatMessage } from '../lib/chat-types.ts';
-import type { DecoroMessage } from '../lib/use-decoro-chat.ts';
-import { useDecoroChat } from '../lib/use-decoro-chat.ts';
+import { type DecoroMessage, useDecoroChat } from '../lib/use-decoro-chat.ts';
+import { usePreviewBroadcast } from '../lib/use-preview-broadcast.ts';
 import { ChatPane } from './chat-pane.tsx';
-import { CodePanel } from './code-panel.tsx';
-import { PreviewFrame } from './preview-frame.tsx';
-import { ShareButton } from './share-button.tsx';
-import {
-  CodeBracketsIcon,
-  type TabItem,
-  TabSwitcher,
-} from './tab-switcher.tsx';
-
-type OutputTab = 'preview' | 'code';
-
-const OUTPUT_TABS: ReadonlyArray<TabItem<OutputTab>> = [
-  { id: 'preview', label: 'Preview', icon: <ViewIcon size="sm" /> },
-  { id: 'code', label: 'Code', icon: <CodeBracketsIcon /> },
-];
+import { OutputPanel } from './output-panel.tsx';
 
 export type WorkspaceSeed = {
   initialState: { messages: DecoroMessage[]; spec: Spec | null } | null;
@@ -31,25 +15,31 @@ export type WorkspaceSeed = {
 
 type Props = {
   seed: WorkspaceSeed;
+  /**
+   * Forwarded to the chat hook. Fires once when the first save mints a
+   * new conversation row — the parent updates the URL so a refresh
+   * lands on the same conversation.
+   */
+  onConversationCreated: (id: string) => void;
 };
 
 /**
- * The chat + preview + code panes. Re-mounts (via `key` from the parent)
+ * The chat + output composite. Re-mounts (via `key` from the parent)
  * whenever the seed changes, so `useDecoroChat`'s `useState` initializer
  * picks up the new initial messages / spec / conversationId without
  * needing a manual reset path on the hook.
- *
- * Lives in its own module so the parent shell stays under the
- * max-dependencies lint cap and the chat / preview / output concerns are
- * grouped together.
  */
-export const HomeWorkspace = ({ seed }: Props) => {
+export const HomeWorkspace = ({ seed, onConversationCreated }: Props) => {
   const { messages, spec, isStreaming, error, send } = useDecoroChat({
     api: '/api/generate',
     initialState: seed.initialState,
     initialConversationId: seed.conversationId,
+    onConversationCreated,
   });
-  const [tab, setTab] = useState<OutputTab>('preview');
+
+  // Broadcast spec changes on the preview channel so any popped-out
+  // window stays in sync with the embedded iframe.
+  usePreviewBroadcast(spec);
 
   const chatMessages: ChatMessage[] = messages.map((m) => ({
     id: m.id,
@@ -72,32 +62,11 @@ export const HomeWorkspace = ({ seed }: Props) => {
           }}
         />
       </section>
-      <section
-        aria-label="Output"
-        className="bg-bg-base flex flex-1 flex-col overflow-hidden rounded-xl shadow-sm"
-      >
-        <div className="border-border-subtle flex items-center justify-between border-b px-2 py-1">
-          <TabSwitcher
-            ariaLabel="Output"
-            tabs={OUTPUT_TABS}
-            value={tab}
-            onChange={setTab}
-          />
-          <ShareButton
-            spec={spec}
-            messages={chatMessages}
-            isStreaming={isStreaming}
-          />
-        </div>
-        <div className="relative flex-1 overflow-hidden">
-          <div hidden={tab !== 'preview'} className="h-full">
-            <PreviewFrame spec={spec} />
-          </div>
-          <div hidden={tab !== 'code'} className="h-full overflow-auto">
-            <CodePanel spec={spec} />
-          </div>
-        </div>
-      </section>
+      <OutputPanel
+        spec={spec}
+        chatMessages={chatMessages}
+        isStreaming={isStreaming}
+      />
     </>
   );
 };

--- a/apps/web/src/components/home-workspace.tsx
+++ b/apps/web/src/components/home-workspace.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import type { Spec } from '@json-render/core';
+import { ViewIcon } from '@k8o/arte-odyssey';
+import { useState } from 'react';
+
+import type { ChatMessage } from '../lib/chat-types.ts';
+import type { DecoroMessage } from '../lib/use-decoro-chat.ts';
+import { useDecoroChat } from '../lib/use-decoro-chat.ts';
+import { ChatPane } from './chat-pane.tsx';
+import { CodePanel } from './code-panel.tsx';
+import { PreviewFrame } from './preview-frame.tsx';
+import { ShareButton } from './share-button.tsx';
+import {
+  CodeBracketsIcon,
+  type TabItem,
+  TabSwitcher,
+} from './tab-switcher.tsx';
+
+type OutputTab = 'preview' | 'code';
+
+const OUTPUT_TABS: ReadonlyArray<TabItem<OutputTab>> = [
+  { id: 'preview', label: 'Preview', icon: <ViewIcon size="sm" /> },
+  { id: 'code', label: 'Code', icon: <CodeBracketsIcon /> },
+];
+
+export type WorkspaceSeed = {
+  initialState: { messages: DecoroMessage[]; spec: Spec | null } | null;
+  conversationId: string | null;
+};
+
+type Props = {
+  seed: WorkspaceSeed;
+};
+
+/**
+ * The chat + preview + code panes. Re-mounts (via `key` from the parent)
+ * whenever the seed changes, so `useDecoroChat`'s `useState` initializer
+ * picks up the new initial messages / spec / conversationId without
+ * needing a manual reset path on the hook.
+ *
+ * Lives in its own module so the parent shell stays under the
+ * max-dependencies lint cap and the chat / preview / output concerns are
+ * grouped together.
+ */
+export const HomeWorkspace = ({ seed }: Props) => {
+  const { messages, spec, isStreaming, error, send } = useDecoroChat({
+    api: '/api/generate',
+    initialState: seed.initialState,
+    initialConversationId: seed.conversationId,
+  });
+  const [tab, setTab] = useState<OutputTab>('preview');
+
+  const chatMessages: ChatMessage[] = messages.map((m) => ({
+    id: m.id,
+    role: m.role,
+    text: m.text,
+  }));
+
+  return (
+    <>
+      <section
+        aria-label="Chat"
+        className="bg-bg-base flex w-5/12 flex-col overflow-hidden rounded-xl shadow-sm"
+      >
+        <ChatPane
+          messages={chatMessages}
+          isStreaming={isStreaming}
+          error={error}
+          onSubmit={(prompt) => {
+            void send(prompt);
+          }}
+        />
+      </section>
+      <section
+        aria-label="Output"
+        className="bg-bg-base flex flex-1 flex-col overflow-hidden rounded-xl shadow-sm"
+      >
+        <div className="border-border-subtle flex items-center justify-between border-b px-2 py-1">
+          <TabSwitcher
+            ariaLabel="Output"
+            tabs={OUTPUT_TABS}
+            value={tab}
+            onChange={setTab}
+          />
+          <ShareButton
+            spec={spec}
+            messages={chatMessages}
+            isStreaming={isStreaming}
+          />
+        </div>
+        <div className="relative flex-1 overflow-hidden">
+          <div hidden={tab !== 'preview'} className="h-full">
+            <PreviewFrame spec={spec} />
+          </div>
+          <div hidden={tab !== 'code'} className="h-full overflow-auto">
+            <CodePanel spec={spec} />
+          </div>
+        </div>
+      </section>
+    </>
+  );
+};

--- a/apps/web/src/components/output-panel.tsx
+++ b/apps/web/src/components/output-panel.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import type { Spec } from '@json-render/core';
+import { ViewIcon } from '@k8o/arte-odyssey';
+import { useState } from 'react';
+
+import type { ChatMessage } from '../lib/chat-types.ts';
+import { CodePanel } from './code-panel.tsx';
+import { PreviewFrame } from './preview-frame.tsx';
+import { PreviewPopoutButton } from './preview-popout-button.tsx';
+import { ShareButton } from './share-button.tsx';
+import {
+  CodeBracketsIcon,
+  type TabItem,
+  TabSwitcher,
+} from './tab-switcher.tsx';
+
+type OutputTab = 'preview' | 'code';
+
+const OUTPUT_TABS: ReadonlyArray<TabItem<OutputTab>> = [
+  { id: 'preview', label: 'Preview', icon: <ViewIcon size="sm" /> },
+  { id: 'code', label: 'Code', icon: <CodeBracketsIcon /> },
+];
+
+type Props = {
+  spec: Spec | null;
+  chatMessages: ChatMessage[];
+  isStreaming: boolean;
+};
+
+/**
+ * Right-pane shell: tab switcher (Preview / Code), the popout button when
+ * Preview is active, and the Share button. Both tab contents are kept
+ * mounted via `hidden` so the iframe's BroadcastChannel subscription
+ * (and any popped-out window) survives tab switches.
+ *
+ * Lives in its own module so HomeWorkspace stays under the
+ * max-dependencies lint cap.
+ */
+export const OutputPanel = ({ spec, chatMessages, isStreaming }: Props) => {
+  const [tab, setTab] = useState<OutputTab>('preview');
+  return (
+    <section
+      aria-label="Output"
+      className="bg-bg-base flex flex-1 flex-col overflow-hidden rounded-xl shadow-sm"
+    >
+      <div className="border-border-subtle flex items-center justify-between border-b px-2 py-1">
+        <TabSwitcher
+          ariaLabel="Output"
+          tabs={OUTPUT_TABS}
+          value={tab}
+          onChange={setTab}
+        />
+        <div className="flex items-center gap-1">
+          {tab === 'preview' ? <PreviewPopoutButton /> : null}
+          <ShareButton
+            spec={spec}
+            messages={chatMessages}
+            isStreaming={isStreaming}
+          />
+        </div>
+      </div>
+      <div className="relative flex-1 overflow-hidden">
+        <div hidden={tab !== 'preview'} className="h-full">
+          <PreviewFrame />
+        </div>
+        <div hidden={tab !== 'code'} className="h-full overflow-auto">
+          <CodePanel spec={spec} />
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/apps/web/src/components/preview-frame.tsx
+++ b/apps/web/src/components/preview-frame.tsx
@@ -1,63 +1,21 @@
-'use client';
-
-import type { Spec } from '@json-render/core';
-import { useEffect, useRef, useState } from 'react';
-
-import {
-  type PreviewInboundMessage,
-  isPreviewMessage,
-} from '../lib/preview-message.ts';
-
-type Props = {
-  spec: Spec | null;
-};
-
 /**
- * Hosts the `/preview` page in an iframe and pushes the current Spec into it
- * via postMessage. Re-sends whenever `spec` changes after the iframe is ready.
+ * Hosts the `/preview` route in an iframe so the adapter's style space
+ * stays isolated from Decoro's own UI (ADR-006).
  *
- * `spec === null` means the user has not asked for anything yet — leave the
- * iframe in its built-in "Waiting for a spec…" state instead of posting.
+ * Spec sync runs over a BroadcastChannel rather than parent↔iframe
+ * postMessage — see `lib/use-preview-broadcast.ts`. Both the embedded
+ * iframe and any popped-out preview window subscribe to the same
+ * channel, so this component just renders the iframe and otherwise has
+ * nothing to wire up.
  */
-export const PreviewFrame = ({ spec }: Props) => {
-  const iframeRef = useRef<HTMLIFrameElement>(null);
-  const [ready, setReady] = useState(false);
-
-  useEffect(() => {
-    const handler = (event: MessageEvent) => {
-      // Origin check alone lets any other same-origin window (devtools panes,
-      // future admin pages, etc.) impersonate the iframe. The source check
-      // pins acceptance to the Window we actually own.
-      if (event.source !== iframeRef.current?.contentWindow) return;
-      if (event.origin !== window.location.origin) return;
-      if (!isPreviewMessage(event.data)) return;
-      if (event.data.type === 'decoro:ready') setReady(true);
-    };
-    window.addEventListener('message', handler);
-    return () => {
-      window.removeEventListener('message', handler);
-    };
-  }, []);
-
-  useEffect(() => {
-    if (!ready || spec === null) return;
-    const message: PreviewInboundMessage = { type: 'decoro:spec', spec };
-    iframeRef.current?.contentWindow?.postMessage(
-      message,
-      window.location.origin,
-    );
-  }, [ready, spec]);
-
-  return (
-    // The iframe exists for style-space isolation (ADR-006), not for security
-    // sandboxing — both sides are first-party Decoro routes, so an HTML
-    // sandbox would only obstruct postMessage without buying anything.
-    // oxlint-disable-next-line eslint-plugin-react(iframe-missing-sandbox)
-    <iframe
-      ref={iframeRef}
-      src="/preview"
-      title="Decoro preview"
-      className="size-full border-0"
-    />
-  );
-};
+export const PreviewFrame = () => (
+  // The iframe exists for style-space isolation (ADR-006), not for security
+  // sandboxing — both sides are first-party Decoro routes, so an HTML
+  // sandbox would only obstruct messaging without buying anything.
+  // oxlint-disable-next-line eslint-plugin-react(iframe-missing-sandbox)
+  <iframe
+    src="/preview"
+    title="Decoro preview"
+    className="size-full border-0"
+  />
+);

--- a/apps/web/src/components/preview-popout-button.tsx
+++ b/apps/web/src/components/preview-popout-button.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { ExternalLinkIcon, IconButton } from '@k8o/arte-odyssey';
+
+const openPreviewPopout = () => {
+  // Sized to fit a 1280×800 reference design with browser chrome.
+  // `noopener` is fine — same-origin BroadcastChannel is the transport,
+  // we don't need an opener reference.
+  window.open(
+    '/preview',
+    'decoro-preview',
+    'popup,width=1280,height=900,noopener',
+  );
+};
+
+/**
+ * Pops the preview iframe out into a new browser window so the spec
+ * has more screen real estate. The new window points at `/preview`
+ * (same route the embedded iframe uses) and subscribes to the same
+ * BroadcastChannel, so spec updates land in both surfaces in lockstep.
+ */
+export const PreviewPopoutButton = () => (
+  <IconButton
+    label="Open preview in a new window"
+    size="sm"
+    bg="transparent"
+    onAction={openPreviewPopout}
+  >
+    <ExternalLinkIcon size="sm" />
+  </IconButton>
+);

--- a/apps/web/src/components/share-view.tsx
+++ b/apps/web/src/components/share-view.tsx
@@ -48,7 +48,14 @@ export const ShareView = ({ snapshot }: Props) => {
     <div className="bg-bg-surface text-fg-base flex h-dvh flex-col">
       <AppHeader
         tagline="Shared snapshot · read-only"
-        rightSlot={<Anchor href="/">Open Decoro →</Anchor>}
+        rightSlot={
+          <div className="flex items-center gap-4">
+            <Anchor href={`/?from=${snapshot.id}`}>
+              Continue this conversation →
+            </Anchor>
+            <Anchor href="/">Open Decoro</Anchor>
+          </div>
+        }
       />
       <main className="flex flex-1 gap-4 overflow-hidden p-4">
         <section

--- a/apps/web/src/components/share-view.tsx
+++ b/apps/web/src/components/share-view.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 
 import type { SnapshotRecord } from '../lib/share-types.ts';
 import { toSpec } from '../lib/spec-schema.ts';
+import { usePreviewBroadcast } from '../lib/use-preview-broadcast.ts';
 import { AppHeader } from './app-header.tsx';
 import { CodePanel } from './code-panel.tsx';
 import { PreviewFrame } from './preview-frame.tsx';
@@ -32,6 +33,10 @@ const OUTPUT_TABS: ReadonlyArray<TabItem<OutputTab>> = [
 export const ShareView = ({ snapshot }: Props) => {
   const [tab, setTab] = useState<OutputTab>('preview');
   const spec = toSpec(snapshot.spec);
+  // Broadcast on the preview channel so the embedded iframe receives the
+  // spec via the same mechanism HomeShell uses, and so popping out the
+  // preview window from a share page works without extra wiring.
+  usePreviewBroadcast(spec);
   // Format the captured-at stamp on the client only. `toLocaleString()`
   // depends on the runtime's locale + timezone; running it during SSR and
   // again on hydration produces a mismatch warning whenever the recipient's
@@ -107,7 +112,7 @@ export const ShareView = ({ snapshot }: Props) => {
           />
           <div className="relative flex-1 overflow-hidden">
             <div hidden={tab !== 'preview'} className="h-full">
-              <PreviewFrame spec={spec} />
+              <PreviewFrame />
             </div>
             <div hidden={tab !== 'code'} className="h-full overflow-auto">
               <CodePanel spec={spec} />

--- a/apps/web/src/lib/conversation-store.ts
+++ b/apps/web/src/lib/conversation-store.ts
@@ -1,0 +1,163 @@
+// `server-only` is a side-effect import that makes the bundler refuse to
+// include this module in client code. Postgres connection lives here.
+// oxlint-disable-next-line eslint-plugin-import(no-unassigned-import)
+import 'server-only';
+import { desc, eq } from 'drizzle-orm';
+
+import {
+  CONVERSATION_ID_PATTERN,
+  type ConversationInput,
+  type ConversationRecord,
+  type ConversationSummary,
+  conversationRecordSchema,
+} from './conversation-types.ts';
+import { db, schema } from './db/client.ts';
+
+/**
+ * Postgres-backed conversation store. Symmetrical with `share-store.ts`,
+ * but mutable: chats keep updating in place rather than producing
+ * append-only snapshots.
+ *
+ * Read validation runs the row through `conversationRecordSchema` so a
+ * JSONB column tampered with directly in the DB still falls back to
+ * "looks missing" rather than crashing the chat page.
+ */
+
+const TITLE_FALLBACK_MAX_CHARS = 80;
+
+/**
+ * Fall back to a title derived from the first user message when the row
+ * has no explicit title set. Truncates so the sidebar doesn't overflow.
+ * "Untitled" is the last resort for genuinely empty conversations
+ * (shouldn't happen — POST requires at least one message — but the type
+ * is still nullable so be defensive).
+ */
+const deriveTitle = (
+  title: string | null,
+  messages: ConversationInput['messages'],
+): string => {
+  if (title !== null && title !== '') return title;
+  const firstUser = messages.find((m) => m.role === 'user');
+  if (!firstUser || firstUser.text === '') return 'Untitled';
+  if (firstUser.text.length <= TITLE_FALLBACK_MAX_CHARS) return firstUser.text;
+  return `${firstUser.text.slice(0, TITLE_FALLBACK_MAX_CHARS - 1)}…`;
+};
+
+export const listConversations = async (): Promise<ConversationSummary[]> => {
+  const rows = await db
+    .select({
+      id: schema.conversations.id,
+      title: schema.conversations.title,
+      messages: schema.conversations.messages,
+      createdAt: schema.conversations.createdAt,
+      updatedAt: schema.conversations.updatedAt,
+    })
+    .from(schema.conversations)
+    .orderBy(desc(schema.conversations.updatedAt));
+
+  return rows.map((row) => ({
+    id: row.id,
+    title: deriveTitle(
+      row.title,
+      // The list-route projection returns the JSONB unparsed; cast to
+      // the message-array shape we know it has (validated on every write).
+      row.messages as ConversationInput['messages'],
+    ),
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  }));
+};
+
+export const getConversation = async (
+  id: string,
+): Promise<ConversationRecord | null> => {
+  if (!CONVERSATION_ID_PATTERN.test(id)) return null;
+  const rows = await db
+    .select()
+    .from(schema.conversations)
+    .where(eq(schema.conversations.id, id))
+    .limit(1);
+  const row = rows[0];
+  if (!row) return null;
+  const parsed = conversationRecordSchema.safeParse({
+    id: row.id,
+    title: row.title,
+    messages: row.messages,
+    spec: row.spec,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  });
+  if (!parsed.success) {
+    console.error(
+      `[conversation-store] schema mismatch for ${id}:`,
+      parsed.error,
+    );
+    return null;
+  }
+  return parsed.data;
+};
+
+/**
+ * Inserts a new conversation row. Generates `created_at` / `updated_at`
+ * via the column defaults so the server clock owns the timestamps.
+ */
+export const createConversation = async (
+  id: string,
+  input: ConversationInput,
+): Promise<void> => {
+  await db.insert(schema.conversations).values({
+    id,
+    title: input.title ?? null,
+    messages: input.messages,
+    spec: input.spec,
+  });
+};
+
+/**
+ * Overwrites an existing conversation row with the latest state. `updated_at`
+ * is bumped to the current time so the sidebar's most-recent ordering stays
+ * correct.
+ *
+ * `title` semantics: undefined means "leave the existing title alone",
+ * `null` means "explicitly clear" (fall back to the derived title), a
+ * string means "set". The chat hook saves on every assistant turn
+ * without sending `title`, so we must NOT overwrite a user-set title
+ * just because the auto-save call omitted the field.
+ *
+ * Returns whether the update touched a row — false means the id was
+ * unknown (the route maps that to a 404).
+ */
+export const updateConversation = async (
+  id: string,
+  input: ConversationInput,
+): Promise<boolean> => {
+  if (!CONVERSATION_ID_PATTERN.test(id)) return false;
+  const set: {
+    messages: ConversationInput['messages'];
+    spec: ConversationInput['spec'];
+    updatedAt: Date;
+    title?: string | null;
+  } = {
+    messages: input.messages,
+    spec: input.spec,
+    updatedAt: new Date(),
+  };
+  if (input.title !== undefined) {
+    set.title = input.title;
+  }
+  const result = await db
+    .update(schema.conversations)
+    .set(set)
+    .where(eq(schema.conversations.id, id))
+    .returning({ id: schema.conversations.id });
+  return result.length > 0;
+};
+
+export const deleteConversation = async (id: string): Promise<boolean> => {
+  if (!CONVERSATION_ID_PATTERN.test(id)) return false;
+  const result = await db
+    .delete(schema.conversations)
+    .where(eq(schema.conversations.id, id))
+    .returning({ id: schema.conversations.id });
+  return result.length > 0;
+};

--- a/apps/web/src/lib/conversation-types.ts
+++ b/apps/web/src/lib/conversation-types.ts
@@ -1,0 +1,78 @@
+import { z } from 'zod';
+
+import { chatMessageSchema } from './chat-types.ts';
+import { MAX_MESSAGES, specSchema } from './spec-schema.ts';
+
+/**
+ * Per-team conversation persistence (per ADR-015). Decoro is a team-scoped
+ * self-host (concept.md), so there is no per-user identity here — every
+ * conversation in the deployment is visible to anyone who can reach the
+ * server, just like shares.
+ *
+ * Conversations are MUTABLE (unlike shares): every chat turn updates the
+ * row in place, the sidebar shows the latest snapshot, and the operator
+ * can come back to any past conversation and keep typing.
+ */
+
+/**
+ * URL-safe base64 id, same shape and entropy as `SHARE_ID_PATTERN` in
+ * share-types. Reused so callers can validate an id received from a URL
+ * without caring whether it's a share or a conversation; the routes
+ * separate the namespaces.
+ */
+export const CONVERSATION_ID_PATTERN = /^[A-Za-z0-9_-]{12}$/;
+
+export const newConversationId = (): string => {
+  const bytes = new Uint8Array(9);
+  crypto.getRandomValues(bytes);
+  let str = '';
+  for (const b of bytes) str += String.fromCodePoint(b);
+  return btoa(str)
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replaceAll('=', '');
+};
+
+const MAX_TITLE_CHARS = 120;
+
+/**
+ * Body schema for `POST /api/conversations` and `PATCH /api/conversations/[id]`.
+ * Both endpoints accept the same shape — POST seeds a new row, PATCH
+ * overwrites the messages / spec / title of an existing one. The chat hook
+ * sends the full conversation state on every save (small payloads, no
+ * partial-update complexity).
+ */
+export const conversationInputSchema = z.object({
+  messages: z.array(chatMessageSchema).min(1).max(MAX_MESSAGES),
+  spec: specSchema,
+  title: z.string().min(1).max(MAX_TITLE_CHARS).nullable().optional(),
+});
+
+/**
+ * Full row shape returned from the API. `title` is nullable in the DB; the
+ * sidebar derives a fallback ("Untitled" / first user-message excerpt) at
+ * render time when it's null.
+ */
+export const conversationRecordSchema = conversationInputSchema.extend({
+  id: z.string().regex(CONVERSATION_ID_PATTERN),
+  createdAt: z.iso.datetime(),
+  updatedAt: z.iso.datetime(),
+  title: z.string().min(1).max(MAX_TITLE_CHARS).nullable(),
+});
+
+/**
+ * Light-weight shape for the sidebar list — drops the heavy `messages` /
+ * `spec` JSONB so the list endpoint stays fast even with many rows. Title
+ * is server-resolved (uses the column when set, else the first user
+ * message, truncated).
+ */
+export const conversationSummarySchema = z.object({
+  id: z.string().regex(CONVERSATION_ID_PATTERN),
+  title: z.string().min(1).max(MAX_TITLE_CHARS),
+  createdAt: z.iso.datetime(),
+  updatedAt: z.iso.datetime(),
+});
+
+export type ConversationInput = z.infer<typeof conversationInputSchema>;
+export type ConversationRecord = z.infer<typeof conversationRecordSchema>;
+export type ConversationSummary = z.infer<typeof conversationSummarySchema>;

--- a/apps/web/src/lib/db/client.ts
+++ b/apps/web/src/lib/db/client.ts
@@ -1,0 +1,35 @@
+// `server-only` is a side-effect import that makes the bundler refuse to
+// include this module in client code. The Postgres driver and connection
+// string are server-side only.
+// oxlint-disable-next-line eslint-plugin-import(no-unassigned-import)
+import 'server-only';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+
+import * as schema from './schema.ts';
+
+/**
+ * Singleton Postgres connection pool + Drizzle client.
+ *
+ * Module-level instantiation is intentional: Next.js dev hot-reloads route
+ * handlers but keeps the module instance, so the pool is created once per
+ * server lifetime instead of per request. In production (next start) the
+ * same applies — one pool per process.
+ */
+const databaseUrl = process.env['DATABASE_URL'];
+if (databaseUrl === undefined || databaseUrl === '') {
+  throw new Error(
+    'DATABASE_URL is not set. Copy `.env.example` to `apps/web/.env.local` and start Postgres with `docker compose up -d` from the repo root.',
+  );
+}
+
+const queryClient = postgres(databaseUrl, {
+  // Default 10 concurrent connections is plenty for a self-hosted single-
+  // instance Decoro. Bump if you put it behind a load balancer with high
+  // concurrent traffic (and add PgBouncer in front).
+  max: 10,
+});
+
+export const db = drizzle(queryClient, { schema });
+
+export { schema };

--- a/apps/web/src/lib/db/client.ts
+++ b/apps/web/src/lib/db/client.ts
@@ -11,25 +11,47 @@ import * as schema from './schema.ts';
 /**
  * Singleton Postgres connection pool + Drizzle client.
  *
- * Module-level instantiation is intentional: Next.js dev hot-reloads route
- * handlers but keeps the module instance, so the pool is created once per
- * server lifetime instead of per request. In production (next start) the
- * same applies — one pool per process.
+ * Lazy-initialized on first access. Module-level eager init was the
+ * original shape, but Next.js's build step does a "collect page data"
+ * pass that imports route modules without runtime env vars present.
+ * Eagerly throwing on missing `DATABASE_URL` failed the build for any
+ * deployment that wires the env in at runtime (Vercel, Docker run,
+ * etc.). Deferring lets module evaluation succeed and surfaces the
+ * config error only when the connection is actually used.
+ *
+ * Once a pool is created it persists for the process lifetime —
+ * Next dev hot-reloads route handlers but keeps the module instance,
+ * and `next start` runs one process per worker.
  */
-const databaseUrl = process.env['DATABASE_URL'];
-if (databaseUrl === undefined || databaseUrl === '') {
-  throw new Error(
-    'DATABASE_URL is not set. Copy `.env.example` to `apps/web/.env.local` and start Postgres with `docker compose up -d` from the repo root.',
-  );
-}
 
-const queryClient = postgres(databaseUrl, {
-  // Default 10 concurrent connections is plenty for a self-hosted single-
-  // instance Decoro. Bump if you put it behind a load balancer with high
-  // concurrent traffic (and add PgBouncer in front).
-  max: 10,
+type DrizzleDb = ReturnType<typeof drizzle<typeof schema>>;
+
+let dbInstance: DrizzleDb | null = null;
+
+const ensureDb = (): DrizzleDb => {
+  if (dbInstance) return dbInstance;
+  const databaseUrl = process.env['DATABASE_URL'];
+  if (databaseUrl === undefined || databaseUrl === '') {
+    throw new Error(
+      'DATABASE_URL is not set. Copy `.env.example` to `apps/web/.env.local` and start Postgres with `docker compose up -d` from the repo root.',
+    );
+  }
+  // Default 10 concurrent connections is plenty for a self-hosted
+  // single-instance Decoro. Bump if you put it behind a load
+  // balancer with high concurrent traffic (and add PgBouncer in front).
+  dbInstance = drizzle(postgres(databaseUrl, { max: 10 }), { schema });
+  return dbInstance;
+};
+
+/**
+ * Proxy that defers initialization until the first method call. Caller
+ * code keeps writing `db.select(...)` / `db.insert(...)` as if the
+ * client were eagerly created.
+ */
+export const db = new Proxy({} as DrizzleDb, {
+  get(_target, prop, receiver) {
+    return Reflect.get(ensureDb(), prop, receiver) as unknown;
+  },
 });
-
-export const db = drizzle(queryClient, { schema });
 
 export { schema };

--- a/apps/web/src/lib/db/migrate-from-fs.ts
+++ b/apps/web/src/lib/db/migrate-from-fs.ts
@@ -1,0 +1,143 @@
+/**
+ * One-shot migrator: reads `<repo-root>/.decoro-shares/*.json` (the legacy
+ * filesystem snapshot store from ADR-013) and inserts each record into the
+ * Postgres `shares` table.
+ *
+ * Idempotent: snapshots that already exist in Postgres are skipped (the
+ * primary-key collision short-circuits with a counter bump rather than an
+ * error). Re-running the script after a partial first run is safe.
+ *
+ * Run with: `pnpm migrate:from-fs` from `apps/web/`. Make sure
+ * `DATABASE_URL` is in `.env.local` and the schema is migrated first
+ * (`pnpm db:migrate`).
+ *
+ * After a successful run, the `.decoro-shares/` directory can be removed
+ * by hand. The script does NOT delete it — preserving the source files
+ * gives the operator a recovery path if the Postgres data is lost.
+ */
+import { readFile, readdir } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+
+import { snapshotRecordSchema } from '../share-types.ts';
+import * as schema from './schema.ts';
+
+// Build a Drizzle client inline rather than importing `./client.ts`. The
+// runtime client pulls in `server-only`, which resolves correctly inside
+// the Next.js bundler but fails as a plain `tsx` script (no bundler =
+// no alias). This script only runs ad-hoc from the CLI, so reconstructing
+// the connection here keeps it self-contained.
+const databaseUrl = process.env['DATABASE_URL'];
+if (databaseUrl === undefined || databaseUrl === '') {
+  throw new Error(
+    'DATABASE_URL is not set. Source `apps/web/.env.local` or export it before running this script.',
+  );
+}
+const queryClient = postgres(databaseUrl, { max: 2 });
+const db = drizzle(queryClient, { schema });
+
+const SHARES_DIR = resolve(process.cwd(), '.decoro-shares');
+
+const main = async () => {
+  let entries: string[];
+  try {
+    entries = await readdir(SHARES_DIR);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      console.warn(
+        `[migrate-from-fs] no ${SHARES_DIR} directory; nothing to migrate.`,
+      );
+      return;
+    }
+    throw err;
+  }
+
+  const jsonFiles = entries.filter((name) => name.endsWith('.json'));
+  if (jsonFiles.length === 0) {
+    console.warn('[migrate-from-fs] no JSON snapshots found.');
+    return;
+  }
+
+  let inserted = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const name of jsonFiles) {
+    const path = join(SHARES_DIR, name);
+    let raw: string;
+    try {
+      // oxlint-disable-next-line eslint(no-await-in-loop)
+      raw = await readFile(path, 'utf8');
+    } catch (err) {
+      console.error(`[migrate-from-fs] read failed for ${name}:`, err);
+      failed += 1;
+      continue;
+    }
+    let data: unknown;
+    try {
+      data = JSON.parse(raw);
+    } catch (err) {
+      console.error(`[migrate-from-fs] corrupt JSON in ${name}:`, err);
+      failed += 1;
+      continue;
+    }
+    const parsed = snapshotRecordSchema.safeParse(data);
+    if (!parsed.success) {
+      console.error(
+        `[migrate-from-fs] schema mismatch in ${name}:`,
+        parsed.error.message,
+      );
+      failed += 1;
+      continue;
+    }
+    const record = parsed.data;
+    try {
+      // Sequential awaits — INSERTs are quick, dataset is small (dozens
+      // of dogfood snapshots at most), and parallelizing would only make
+      // the failure log harder to read.
+      // oxlint-disable-next-line eslint(no-await-in-loop)
+      await db.insert(schema.shares).values({
+        id: record.id,
+        createdAt: new Date(record.createdAt),
+        schemaVersion: record.schemaVersion,
+        messages: record.messages,
+        spec: record.spec,
+        parentShareId: null,
+      });
+      inserted += 1;
+    } catch (err) {
+      // Unique-violation = already migrated. Drizzle may wrap the
+      // postgres-js PostgresError in its own DrizzleQueryError, so check
+      // both `err.code` and `err.cause.code` for the SQLSTATE.
+      const code =
+        typeof err === 'object' && err !== null
+          ? ((err as { code?: string }).code ??
+            (err as { cause?: { code?: string } }).cause?.code)
+          : undefined;
+      if (code === '23505') {
+        skipped += 1;
+      } else {
+        console.error(`[migrate-from-fs] insert failed for ${name}:`, err);
+        failed += 1;
+      }
+    }
+  }
+
+  console.warn(
+    `[migrate-from-fs] done. inserted=${inserted.toString()} skipped=${skipped.toString()} failed=${failed.toString()}`,
+  );
+  if (failed > 0) {
+    process.exit(1);
+  }
+};
+
+try {
+  await main();
+} catch (err) {
+  console.error('[migrate-from-fs] fatal:', err);
+  process.exitCode = 1;
+} finally {
+  await queryClient.end();
+}

--- a/apps/web/src/lib/db/schema.ts
+++ b/apps/web/src/lib/db/schema.ts
@@ -1,0 +1,54 @@
+import { integer, jsonb, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+
+/**
+ * Schema for Decoro's Postgres persistence (per ADR-015).
+ *
+ * `messages` and `spec` deliberately stay as `jsonb` rather than being
+ * normalized into separate tables. Every read path wants the full
+ * conversation as a unit (chat pane renders all messages together; preview
+ * re-derives from the full spec), so normalization would cost joins on
+ * every read with no query benefit. JSONB also keeps schema evolution on
+ * the message / spec shape inside the TypeScript Zod layer
+ * (`apps/web/src/lib/share-types.ts`, `chat-types.ts`, `spec-schema.ts`)
+ * without DB migrations.
+ */
+
+/**
+ * Immutable snapshots created via `/api/share` (ADR-013 model). Each row
+ * captures a conversation + spec at a point in time. `parent_share_id`
+ * points back at an earlier share when this snapshot was forked from one,
+ * giving us lineage without a separate edges table.
+ */
+export const shares = pgTable('shares', {
+  id: text('id').primaryKey(),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  schemaVersion: integer('schema_version').notNull(),
+  messages: jsonb('messages').notNull(),
+  spec: jsonb('spec').notNull(),
+  parentShareId: text('parent_share_id'),
+});
+
+/**
+ * Mutable per-team conversation rows. Decoro is a team-scoped self-host
+ * (concept.md), so there is no per-user concept here — every conversation
+ * is visible to anyone who can reach the deployment. `title` is a short
+ * label for the sidebar; null means "derive from the first user message"
+ * at render time.
+ */
+export const conversations = pgTable('conversations', {
+  id: text('id').primaryKey(),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  title: text('title'),
+  messages: jsonb('messages').notNull(),
+  spec: jsonb('spec').notNull(),
+});
+
+export type ShareRow = typeof shares.$inferSelect;
+export type ConversationRow = typeof conversations.$inferSelect;

--- a/apps/web/src/lib/generate-job.ts
+++ b/apps/web/src/lib/generate-job.ts
@@ -1,0 +1,185 @@
+// `server-only` is a side-effect import that makes the bundler refuse
+// to include this module in client code. The job calls `streamText`
+// with server credentials and writes to the DB.
+// oxlint-disable-next-line eslint-plugin-import(no-unassigned-import)
+import 'server-only';
+import { createModel } from '@decoro/llm-config';
+import {
+  type Spec,
+  applySpecPatch,
+  buildUserPrompt,
+  createMixedStreamParser,
+} from '@json-render/core';
+import { type ModelMessage, streamText } from 'ai';
+
+import { adapter, llm } from '../../decoro.config.ts';
+import type { ChatMessage } from './chat-types.ts';
+import { updateConversation } from './conversation-store.ts';
+import { startJob } from './job-store.ts';
+
+// Ask the model to prefix the JSONL stream with a single short natural-
+// language line summarizing what it's building.
+const responsePreambleInstruction = [
+  'Response format (STRICT — the chat UI parses prose vs JSON by line):',
+  '- Line 1: exactly ONE short sentence (≤ 15 words) describing what you are building or changing in this turn. Plain prose, no JSON, no leading whitespace.',
+  '- Line 1 MUST end with a literal newline character before any JSON appears. Do not place JSON on the same line as the sentence.',
+  '- Lines 2+: JSONL patch lines, one complete JSON object per line. No prose between or after the patches.',
+  '- Example shape:',
+  '    Adding a primary submit button.\\n',
+  '    {"op":"add","path":"/elements/btn","value":{"type":"Button","props":{"label":"Save"},"children":[]}}\\n',
+  '    {"op":"replace","path":"/root","value":"btn"}\\n',
+].join('\n');
+
+// Universal spec discipline — applies to every adapter; it's a json-render
+// spec / catalog contract concern, not a design-system one.
+const specDisciplineInstruction = [
+  'Spec discipline:',
+  '- Set only the props each component declares in its catalog entry. Unknown props are silently dropped by codegen.',
+  '- `children` is an array of OTHER element keys, not raw strings. To place literal text, use whatever text primitive the catalog provides (look for an entry like `Text`, or a `text` / `label` / `content` prop on the component itself).',
+  '- If a parent has nothing to say, omit the child — do NOT insert an empty placeholder element.',
+  '- Use ONLY components, props, and enum values that appear in the catalog. Do NOT invent component names, icon names, or option values from libraries the catalog does not list (Material Symbols, Heroicons, MUI, etc.) — they will not resolve and the preview will render raw text or an empty slot.',
+].join('\n');
+
+// Decoro is a design tool — users want to *see* their UI, not run it.
+const mockupFirstInstruction = [
+  'Mockup-first generation:',
+  '- Decoro is a design tool. Users want to SEE the UI populated, not wire up state.',
+  '- Prefer STATIC content baked directly into the spec. Render 2–4 example items inline for chat / list / table / feed UIs so the preview is populated the moment generation finishes.',
+  '- AVOID `$bindEach`, `$bindState`, `$cond`, `$item`, and action bindings (`pushState`, etc.) by default. They produce templates that render empty without state initialization.',
+  '- For form UIs, leave inputs empty (the user fills them); for display UIs, show concrete example values directly in `props`.',
+  '- Only use state bindings / actions when the user EXPLICITLY asks for an interactive prototype.',
+].join('\n');
+
+const systemPrompt = [
+  adapter.catalog.prompt({ mode: 'standalone' }),
+  '',
+  'Library design principles:',
+  adapter.metadata.designPrinciples,
+  ...(adapter.metadata.promptGuidance === undefined
+    ? []
+    : ['', adapter.metadata.promptGuidance]),
+  '',
+  specDisciplineInstruction,
+  '',
+  mockupFirstInstruction,
+  '',
+  responsePreambleInstruction,
+].join('\n');
+
+const isMeaningfulSpec = (spec: Spec): boolean =>
+  spec.root !== '' && Object.keys(spec.elements).length > 0;
+
+const buildLlmMessages = (
+  messages: ChatMessage[],
+  inputSpec: Spec,
+): ModelMessage[] => {
+  const llmMessages: ModelMessage[] = messages
+    .filter((m) => !(m.role === 'assistant' && m.text === ''))
+    .map((m) => ({ role: m.role, content: m.text }));
+  const lastIdx = llmMessages.length - 1;
+  if (lastIdx < 0) return llmMessages;
+  const last = llmMessages[lastIdx];
+  if (last?.role !== 'user' || typeof last.content !== 'string') {
+    return llmMessages;
+  }
+  llmMessages[lastIdx] = {
+    ...last,
+    content: buildUserPrompt({
+      prompt: last.content,
+      currentSpec: isMeaningfulSpec(inputSpec) ? inputSpec : undefined,
+    }),
+  };
+  return llmMessages;
+};
+
+const normalizeSpecForDb = (spec: Spec) => ({
+  root: spec.root,
+  elements: Object.fromEntries(
+    Object.entries(spec.elements).map(([k, v]) => [
+      k,
+      { ...v, children: v.children ?? [] },
+    ]),
+  ),
+  ...(spec.state === undefined ? {} : { state: spec.state }),
+});
+
+/**
+ * Spawns a background LLM stream tied to `conversationId`. Cancels any
+ * previous job for the same conversation, streams chunks into the job
+ * store (which serves the SSE channel), and PATCHes the conversation
+ * row with final state on completion.
+ *
+ * Fire-and-forget from the route: the caller awaits nothing and
+ * returns to the client immediately. Errors are reported through the
+ * job's `fail` event so subscribers see them on the SSE channel.
+ */
+export const startGenerateJob = (params: {
+  conversationId: string;
+  seedMessages: ChatMessage[];
+  seedSpec: Spec;
+}): void => {
+  const { conversationId, seedMessages, seedSpec } = params;
+  const job = startJob(conversationId);
+  const llmMessages = buildLlmMessages(seedMessages, seedSpec);
+
+  void (async () => {
+    let buffer = '';
+    try {
+      const result = streamText({
+        model: createModel(llm),
+        system: systemPrompt,
+        messages: llmMessages,
+        abortSignal: job.signal,
+      });
+
+      for await (const chunk of result.textStream) {
+        if (job.signal.aborted) return;
+        buffer += chunk;
+        job.appendChunk(chunk);
+      }
+
+      // Parse the full buffer to compute the final assistant text + spec
+      // for the DB write. Same parser the client uses, so both sides
+      // stay byte-for-byte consistent.
+      let assistantText = '';
+      const finalSpec: Spec = {
+        root: seedSpec.root,
+        elements: { ...seedSpec.elements },
+        ...(seedSpec.state ? { state: { ...seedSpec.state } } : {}),
+      };
+      const parser = createMixedStreamParser({
+        onText(text) {
+          assistantText += text;
+        },
+        onPatch(patch) {
+          applySpecPatch(finalSpec, patch);
+        },
+      });
+      parser.push(buffer);
+      parser.flush();
+
+      const cleaned = seedMessages.filter(
+        (m) => !(m.role === 'assistant' && m.text === ''),
+      );
+      const finalMessages: ChatMessage[] = [
+        ...cleaned,
+        {
+          id: crypto.randomUUID(),
+          role: 'assistant',
+          text: assistantText,
+        },
+      ];
+
+      await updateConversation(conversationId, {
+        messages: finalMessages,
+        spec: normalizeSpecForDb(finalSpec),
+      });
+      job.complete();
+    } catch (err) {
+      if (job.signal.aborted) return;
+      const message = err instanceof Error ? err.message : 'Stream failed';
+      console.error('[generate-job] stream failed:', err);
+      job.fail(message);
+    }
+  })();
+};

--- a/apps/web/src/lib/generate-job.ts
+++ b/apps/web/src/lib/generate-job.ts
@@ -92,6 +92,17 @@ const buildLlmMessages = (
   return llmMessages;
 };
 
+/**
+ * Hard ceiling on how much the model may emit in a single turn. Sized
+ * for "verbose UI spec for a complex screen" with margin (a typical
+ * full mockup spec runs ~5k tokens; 8k leaves headroom for nested
+ * layouts), but tight enough to kill a runaway in seconds when a model
+ * loops on the prose preamble or the JSONL never converges. The
+ * `streamText` abort propagates through the job's signal, so an
+ * over-cap turn fails fast instead of running for minutes.
+ */
+const MAX_OUTPUT_TOKENS = 8000;
+
 const normalizeSpecForDb = (spec: Spec) => ({
   root: spec.root,
   elements: Object.fromEntries(
@@ -130,6 +141,7 @@ export const startGenerateJob = (params: {
         system: systemPrompt,
         messages: llmMessages,
         abortSignal: job.signal,
+        maxOutputTokens: MAX_OUTPUT_TOKENS,
       });
 
       for await (const chunk of result.textStream) {

--- a/apps/web/src/lib/job-store.ts
+++ b/apps/web/src/lib/job-store.ts
@@ -1,0 +1,199 @@
+// `server-only` is a side-effect import that makes the bundler refuse to
+// include this module in client code. The job store is a per-process
+// in-memory map with subscriber callbacks; client bundling would only
+// confuse the React tree.
+// oxlint-disable-next-line eslint-plugin-import(no-unassigned-import)
+import 'server-only';
+import type { StreamEvent } from './stream-events.ts';
+
+/**
+ * In-memory pub/sub for in-flight LLM streams (per ADR-016).
+ *
+ * Keyed by `conversationId`: at most one job runs per conversation at
+ * a time. Submitting a new turn while one is running cancels the
+ * previous job and emits a `start` event with a fresh `turnId` so any
+ * subscribers reset their parser before chunks for the new turn arrive.
+ *
+ * Each job buffers everything emitted for its current turn so a late
+ * subscriber (a teammate opening the conversation mid-generation, a
+ * client reconnecting after a refresh) replays the full text and then
+ * picks up live chunks. Buffer + subscribers are torn down 60 s after
+ * `done` to leave room for short reconnect windows.
+ *
+ * Per-process state — multi-instance deployments need a shared
+ * pub/sub layer (Postgres LISTEN/NOTIFY or Redis); this is fine for
+ * the single-instance self-host MVP target.
+ */
+
+type JobStatus = 'running' | 'done' | 'error';
+
+type Subscriber = (event: StreamEvent) => void;
+
+type Job = {
+  conversationId: string;
+  turnId: string;
+  buffer: string;
+  status: JobStatus;
+  errorMessage?: string;
+  abort: AbortController;
+  subscribers: Set<Subscriber>;
+  cleanupTimer?: ReturnType<typeof setTimeout>;
+};
+
+const RETENTION_AFTER_DONE_MS = 60_000;
+
+const jobs = new Map<string, Job>();
+
+const newTurnId = (): string => crypto.randomUUID();
+
+const notify = (job: Job, event: StreamEvent) => {
+  for (const sub of job.subscribers) {
+    try {
+      sub(event);
+    } catch (err) {
+      console.error('[job-store] subscriber threw:', err);
+    }
+  }
+};
+
+const scheduleCleanup = (job: Job) => {
+  if (job.cleanupTimer) clearTimeout(job.cleanupTimer);
+  job.cleanupTimer = setTimeout(() => {
+    if (jobs.get(job.conversationId) === job) {
+      jobs.delete(job.conversationId);
+    }
+    job.subscribers.clear();
+  }, RETENTION_AFTER_DONE_MS);
+};
+
+/**
+ * Replace any existing job for `conversationId` with a fresh one. Old
+ * subscribers stay attached and receive a `start` event for the new
+ * turn so their parser resets; the cancelled job's abort signal fires
+ * so its in-flight LLM call short-circuits.
+ *
+ * Returns the job + its abort signal so the caller can wire it into
+ * `streamText`.
+ */
+export const startJob = (
+  conversationId: string,
+): {
+  turnId: string;
+  signal: AbortSignal;
+  appendChunk: (text: string) => void;
+  complete: () => void;
+  fail: (message: string) => void;
+} => {
+  const existing = jobs.get(conversationId);
+  if (existing) {
+    existing.abort.abort();
+    if (existing.cleanupTimer) clearTimeout(existing.cleanupTimer);
+  }
+  const turnId = newTurnId();
+  const job: Job = {
+    conversationId,
+    turnId,
+    buffer: '',
+    status: 'running',
+    abort: new AbortController(),
+    subscribers: existing?.subscribers ?? new Set(),
+  };
+  jobs.set(conversationId, job);
+  notify(job, { type: 'start', turnId });
+  return {
+    turnId,
+    signal: job.abort.signal,
+    appendChunk: (text: string) => {
+      if (job.status !== 'running') return;
+      job.buffer += text;
+      notify(job, { type: 'chunk', turnId, text });
+    },
+    complete: () => {
+      if (job.status !== 'running') return;
+      job.status = 'done';
+      notify(job, { type: 'done', turnId });
+      scheduleCleanup(job);
+    },
+    fail: (message: string) => {
+      if (job.status !== 'running') return;
+      job.status = 'error';
+      job.errorMessage = message;
+      notify(job, { type: 'error', turnId, message });
+      scheduleCleanup(job);
+    },
+  };
+};
+
+/**
+ * Returns whether a job is currently running for `conversationId`.
+ * Used by the sidebar's generating-indicator endpoint and by the SSE
+ * route to decide whether to attach or close immediately.
+ */
+export const isJobRunning = (conversationId: string): boolean => {
+  const job = jobs.get(conversationId);
+  return job?.status === 'running';
+};
+
+/**
+ * List the conversation ids that currently have a running job. Used by
+ * the sidebar's polling indicator so all conversations with in-flight
+ * work show the spinner regardless of which one is active in the UI.
+ */
+export const runningConversationIds = (): string[] => {
+  const ids: string[] = [];
+  for (const [id, job] of jobs) {
+    if (job.status === 'running') ids.push(id);
+  }
+  return ids;
+};
+
+/**
+ * Subscribe to events for a conversation. Immediately replays the
+ * current job's buffer (if any) and then forwards live events. Returns
+ * an unsubscribe function the SSE handler must call when the connection
+ * closes.
+ *
+ * If no job exists for the conversation when the subscription starts,
+ * the subscriber receives a synthetic `done` event so the SSE handler
+ * can close cleanly. This matches the "this conversation is idle"
+ * semantics — the route doesn't need a separate "is there a job?" check.
+ */
+export const subscribe = (
+  conversationId: string,
+  subscriber: Subscriber,
+): (() => void) => {
+  const job = jobs.get(conversationId);
+  if (!job) {
+    // No active job — synthesize a `done` so the client closes the SSE
+    // and falls back to whatever the DB has. The synthetic turn id
+    // doesn't collide with anything because the client only uses it for
+    // matching `chunk` events with their `start`.
+    subscriber({ type: 'done', turnId: 'idle' });
+    return () => {
+      // noop — never attached
+    };
+  }
+  if (job.buffer.length > 0) {
+    subscriber({ type: 'chunk', turnId: job.turnId, text: job.buffer });
+  }
+  if (job.status === 'done') {
+    subscriber({ type: 'done', turnId: job.turnId });
+    return () => {
+      // noop — terminal
+    };
+  }
+  if (job.status === 'error') {
+    subscriber({
+      type: 'error',
+      turnId: job.turnId,
+      message: job.errorMessage ?? 'Stream errored',
+    });
+    return () => {
+      // noop — terminal
+    };
+  }
+  job.subscribers.add(subscriber);
+  return () => {
+    job.subscribers.delete(subscriber);
+  };
+};

--- a/apps/web/src/lib/preview-message.ts
+++ b/apps/web/src/lib/preview-message.ts
@@ -1,20 +1,33 @@
 import type { Spec } from '@json-render/core';
 
 /**
- * Messages exchanged between the parent (`/`) and the preview iframe
- * (`/preview`). All messages share a `decoro:` prefix to make them easy to
- * filter from unrelated postMessage traffic.
+ * Messages exchanged between the main app and any preview surface
+ * (the embedded iframe at `/preview`, plus any popped-out windows the
+ * user opens). All consumers subscribe to a single same-origin
+ * BroadcastChannel, so adding a popout window is "open `/preview` in a
+ * new window" — no new wiring needed.
+ *
+ * All messages share a `decoro:` prefix to make them easy to filter from
+ * unrelated traffic on the channel.
  */
-export type PreviewInboundMessage = {
+export const PREVIEW_CHANNEL = 'decoro:preview';
+
+export type PreviewSpecMessage = {
   type: 'decoro:spec';
   spec: Spec;
 };
 
-export type PreviewOutboundMessage = {
+/**
+ * Sent by a fresh preview surface to ask the main app to re-broadcast the
+ * current spec. The main app's broadcast hook responds with the latest
+ * `decoro:spec` so the new consumer doesn't have to wait for the next
+ * change to populate.
+ */
+export type PreviewReadyMessage = {
   type: 'decoro:ready';
 };
 
-export type PreviewMessage = PreviewInboundMessage | PreviewOutboundMessage;
+export type PreviewMessage = PreviewSpecMessage | PreviewReadyMessage;
 
 export const isPreviewMessage = (value: unknown): value is PreviewMessage => {
   if (typeof value !== 'object' || value === null) return false;

--- a/apps/web/src/lib/share-store.ts
+++ b/apps/web/src/lib/share-store.ts
@@ -1,12 +1,10 @@
 // `server-only` is a side-effect import that makes the bundler refuse to
-// include this module in client code. The store touches the filesystem
-// (`node:fs`, `process.cwd()`); an accidental client import would crash
-// the browser bundle.
+// include this module in client code. Postgres connection lives here.
 // oxlint-disable-next-line eslint-plugin-import(no-unassigned-import)
 import 'server-only';
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { join, resolve } from 'node:path';
+import { eq } from 'drizzle-orm';
 
+import { db, schema } from './db/client.ts';
 import {
   SHARE_ID_PATTERN,
   type SnapshotRecord,
@@ -14,40 +12,26 @@ import {
 } from './share-types.ts';
 
 /**
- * Filesystem-backed snapshot store for shareable spec snapshots.
+ * Postgres-backed share snapshot store (per ADR-015).
  *
- * Snapshots live as one JSON file per id under `<repo-root>/.decoro-shares/`
- * (gitignored). The store deliberately has no delete or update method:
- * snapshots are immutable for the lifetime of the deployment, and removing
- * a share means deleting the file by hand. Suits a single-user self-host
- * setup; multi-user / auth / lifecycle features are a follow-up.
+ * Snapshots are written immutably — the schema has no UPDATE path and the
+ * insert is a plain INSERT (a primary-key collision raises
+ * `SnapshotExistsError`, which the route handler retries with a fresh id).
+ * Reads validate the row against `snapshotRecordSchema` so a JSONB column
+ * tampered with directly in the DB still fails into "looks missing" rather
+ * than crashing the share page.
  *
- * Storage location is fixed for now. A `decoro.config.ts` extension point
- * (filesystem | vercel-kv | sqlite | …) is the natural next step when a
- * deployment target needs something other than local disk.
+ * Public API mirrors the previous filesystem implementation exactly so
+ * route handlers and `share/[id]/page.tsx` need no changes; the migration
+ * happens in this module alone.
  */
-
-const SHARES_DIR = resolve(process.cwd(), '.decoro-shares');
-
-const ensureDir = async () => {
-  await mkdir(SHARES_DIR, { recursive: true });
-};
-
-const filePathFor = (id: string): string => {
-  if (!SHARE_ID_PATTERN.test(id)) {
-    // Validated callers pass through `getSnapshot`; this guard catches
-    // direct misuse + makes it impossible to construct a path that escapes
-    // SHARES_DIR via traversal (`..`, slashes), even by accident.
-    throw new Error(`invalid share id: ${id}`);
-  }
-  return join(SHARES_DIR, `${id}.json`);
-};
 
 /**
  * Sentinel error for callers (e.g. `POST /api/share`) to catch and react to
  * an id collision by regenerating the id and retrying. Carries `code: 'EEXIST'`
  * so callers can match Node's filesystem convention without depending on the
- * underlying error class.
+ * underlying error class — the convention predates the Postgres swap and is
+ * worth keeping for the route's existing retry logic.
  */
 export class SnapshotExistsError extends Error {
   readonly code = 'EEXIST' as const;
@@ -58,20 +42,36 @@ export class SnapshotExistsError extends Error {
 }
 
 /**
- * Writes the snapshot exclusively (`flag: 'wx'`) — fails if a file already
- * exists at the same id. Snapshots are immutable per ADR-013; callers handle
- * the (astronomically rare) collision by regenerating the id and retrying.
+ * Writes the snapshot. Postgres' primary-key constraint enforces the
+ * immutability guarantee — a colliding id surfaces as `SnapshotExistsError`
+ * and the route regenerates the id rather than overwriting.
+ *
+ * `parentShareId` defaults to null (originated standalone). When this
+ * snapshot was created by forking another, the route passes the parent id
+ * so lineage queries become a recursive CTE later.
  */
-export const putSnapshot = async (record: SnapshotRecord): Promise<void> => {
-  await ensureDir();
-  const path = filePathFor(record.id);
+export const putSnapshot = async (
+  record: SnapshotRecord & { parentShareId?: string | null },
+): Promise<void> => {
   try {
-    await writeFile(path, JSON.stringify(record), {
-      encoding: 'utf8',
-      flag: 'wx',
+    await db.insert(schema.shares).values({
+      id: record.id,
+      createdAt: new Date(record.createdAt),
+      schemaVersion: record.schemaVersion,
+      messages: record.messages,
+      spec: record.spec,
+      parentShareId: record.parentShareId ?? null,
     });
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'EEXIST') {
+    // postgres-js surfaces unique-violation as SQLSTATE '23505'. Drizzle
+    // may wrap it in DrizzleQueryError, so check both `err.code` and
+    // `err.cause.code`.
+    const code =
+      typeof err === 'object' && err !== null
+        ? ((err as { code?: string }).code ??
+          (err as { cause?: { code?: string } }).cause?.code)
+        : undefined;
+    if (code === '23505') {
       throw new SnapshotExistsError(record.id);
     }
     throw err;
@@ -79,8 +79,8 @@ export const putSnapshot = async (record: SnapshotRecord): Promise<void> => {
 };
 
 /**
- * Returns `null` for missing snapshots. Returns `null` (not throws) for files
- * that exist but fail re-validation — read corruption shouldn't 500 the share
+ * Returns `null` for missing snapshots. Returns `null` (not throws) for
+ * rows that fail re-validation — schema corruption shouldn't 500 the share
  * page, just look like a missing snapshot. Surfaces the parse error to logs
  * for the operator to diagnose.
  */
@@ -88,21 +88,20 @@ export const getSnapshot = async (
   id: string,
 ): Promise<SnapshotRecord | null> => {
   if (!SHARE_ID_PATTERN.test(id)) return null;
-  let raw: string;
-  try {
-    raw = await readFile(filePathFor(id), 'utf8');
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
-    throw err;
-  }
-  let data: unknown;
-  try {
-    data = JSON.parse(raw);
-  } catch (err) {
-    console.error(`[share-store] corrupt JSON for ${id}:`, err);
-    return null;
-  }
-  const parsed = snapshotRecordSchema.safeParse(data);
+  const rows = await db
+    .select()
+    .from(schema.shares)
+    .where(eq(schema.shares.id, id))
+    .limit(1);
+  const row = rows[0];
+  if (!row) return null;
+  const parsed = snapshotRecordSchema.safeParse({
+    id: row.id,
+    createdAt: row.createdAt.toISOString(),
+    schemaVersion: row.schemaVersion,
+    messages: row.messages,
+    spec: row.spec,
+  });
   if (!parsed.success) {
     console.error(`[share-store] schema mismatch for ${id}:`, parsed.error);
     return null;

--- a/apps/web/src/lib/stream-events.ts
+++ b/apps/web/src/lib/stream-events.ts
@@ -1,0 +1,27 @@
+/**
+ * Wire format for the SSE channel that delivers in-flight LLM output to
+ * the chat UI. Each turn emits a `start` (so reconnecting subscribers
+ * reset their parser cleanly), zero or more `chunk` events with the raw
+ * text the LLM produced, then either `done` or `error`.
+ *
+ * The chunk text is the unparsed mixed prose-then-JSONL stream the
+ * model emits — `createMixedStreamParser` on the client splits prose
+ * (assistant message text) from spec patches. Server-side parsing is
+ * only used to compute the final state for the DB PATCH; per-chunk
+ * deltas reach the client raw, exactly as they would in the
+ * pre-server-streaming design.
+ */
+export type StreamEvent =
+  | { type: 'start'; turnId: string }
+  | { type: 'chunk'; turnId: string; text: string }
+  | { type: 'done'; turnId: string }
+  | { type: 'error'; turnId: string; message: string };
+
+/**
+ * Encode an event as a single SSE record. Each line is `data: <payload>`
+ * followed by a blank line that flushes the message. Newlines inside
+ * `chunk.text` are preserved by JSON-encoding the whole event, so the
+ * client decodes the JSON and gets back the original raw stream.
+ */
+export const encodeStreamEvent = (event: StreamEvent): string =>
+  `data: ${JSON.stringify(event)}\n\n`;

--- a/apps/web/src/lib/use-decoro-chat.ts
+++ b/apps/web/src/lib/use-decoro-chat.ts
@@ -35,6 +35,13 @@ type Options = {
    * leave this unset — the first save then creates a brand-new row.
    */
   initialConversationId?: string | null;
+  /**
+   * Fires once when the first save mints a new conversation row. Used
+   * by the shell to update the URL (`?conversation=<id>`) so a refresh
+   * keeps the user on the same conversation. Not fired on subsequent
+   * PATCH saves or when `initialConversationId` was supplied.
+   */
+  onConversationCreated?: (id: string) => void;
 };
 
 type State = {
@@ -71,6 +78,7 @@ export const useDecoroChat = ({
   persistApi = '/api/conversations',
   initialState = null,
   initialConversationId = null,
+  onConversationCreated,
 }: Options) => {
   const [state, setState] = useState<State>(() =>
     initialState
@@ -93,6 +101,10 @@ export const useDecoroChat = ({
   // synchronously available without forcing a re-render that doesn't
   // change anything visible.
   const conversationIdRef = useRef<string | null>(initialConversationId);
+  // Latest callback in a ref so changing it across renders doesn't
+  // invalidate `persist` (which is in `send`'s dep list).
+  const onCreatedRef = useRef(onConversationCreated);
+  onCreatedRef.current = onConversationCreated;
 
   const persist = useCallback(
     async (messages: DecoroMessage[], spec: Spec | null) => {
@@ -112,6 +124,7 @@ export const useDecoroChat = ({
           if (!res.ok) throw new Error(`POST ${res.status.toString()}`);
           const data = (await res.json()) as { id: string };
           conversationIdRef.current = data.id;
+          onCreatedRef.current?.(data.id);
           return;
         }
         const res = await fetch(`${persistApi}/${conversationIdRef.current}`, {

--- a/apps/web/src/lib/use-decoro-chat.ts
+++ b/apps/web/src/lib/use-decoro-chat.ts
@@ -5,7 +5,10 @@ import {
   applySpecPatch,
   createMixedStreamParser,
 } from '@json-render/core';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import type { ConversationRecord } from './conversation-types.ts';
+import type { StreamEvent } from './stream-events.ts';
 
 export type DecoroMessage = {
   id: string;
@@ -14,32 +17,31 @@ export type DecoroMessage = {
 };
 
 type Options = {
+  /**
+   * Endpoint that mints (or attaches to) a conversation and starts the
+   * server-side LLM job. POSTed to once per turn.
+   */
   api: string;
   /**
-   * Persistence endpoint base. The hook POSTs once to `${persistApi}` to
-   * mint a conversation row on the first stream completion, then PATCHes
-   * `${persistApi}/<id>` on every subsequent assistant turn. Pass `null`
-   * to disable persistence (e.g. demo / test contexts).
+   * Endpoint base for the server-sent events stream that delivers
+   * in-flight chunks. Pass `null` to disable subscription (e.g. tests).
    */
-  persistApi?: string | null;
+  eventsApi?: string | null;
   /**
    * Optional seed for the chat state. Used when continuing from a shared
-   * snapshot or resuming a conversation from the sidebar. When supplied,
-   * `conversationId` should also be set so subsequent saves PATCH the
-   * existing row instead of creating a new one.
+   * snapshot or resuming a conversation from the sidebar.
    */
   initialState?: { messages: DecoroMessage[]; spec: Spec | null } | null;
   /**
-   * Existing conversation row id. When set, the first assistant-turn
-   * save is a PATCH (instead of POST). Forks from a shared snapshot
-   * leave this unset — the first save then creates a brand-new row.
+   * Existing conversation row id. When set, the EventSource attaches
+   * immediately so an in-flight server-side job (started by another
+   * tab, or this tab before a refresh) replays + streams live.
    */
   initialConversationId?: string | null;
   /**
-   * Fires once when the first save mints a new conversation row. Used
+   * Fires once when the first POST mints a new conversation row. Used
    * by the shell to update the URL (`?conversation=<id>`) so a refresh
-   * keeps the user on the same conversation. Not fired on subsequent
-   * PATCH saves or when `initialConversationId` was supplied.
+   * keeps the user on the same conversation.
    */
   onConversationCreated?: (id: string) => void;
 };
@@ -58,24 +60,40 @@ const emptyState: State = {
   error: null,
 };
 
+const buildEmptySpec = (): Spec => ({ root: '', elements: {} });
+
+const cloneSpec = (spec: Spec | null): Spec => {
+  if (!spec) return buildEmptySpec();
+  return {
+    root: spec.root,
+    elements: { ...spec.elements },
+    ...(spec.state ? { state: { ...spec.state } } : {}),
+  };
+};
+
 /**
- * Decoro's chat hook. Wraps the json-render building blocks
- * (`createMixedStreamParser` + `applySpecPatch`) so we can also send the
- * `currentSpec` alongside the message history — `useChatUI` from
- * `@json-render/react` is otherwise a perfect fit but its request body is
- * locked to `{ messages }`, which prevents the iteration loop M8 needs.
+ * Decoro's chat hook. The LLM stream lives on the server (per ADR-016);
+ * this hook submits a turn via `POST /api/generate` and consumes the
+ * resulting stream over `EventSource('/api/conversations/<id>/events')`.
  *
- * Persistence (per ADR-015): when `persistApi` is set, the hook saves
- * the conversation to Postgres after each assistant turn completes. The
- * first save POSTs to mint a new row; subsequent saves PATCH the same id.
- * Failures are logged but never break the chat experience — losing a
- * single auto-save is annoying but recoverable, while propagating the
- * error to the UI would interrupt a working stream for a background
- * concern.
+ * Lifecycle:
+ *   - On mount with `initialConversationId`: open EventSource right
+ *     away. If a job is already running on the server (another tab,
+ *     pre-refresh state), the SSE channel replays the buffer and then
+ *     streams live. Otherwise the SSE handler emits `done` immediately
+ *     and the hook stays idle.
+ *   - On `send`: optimistically append the user message + an empty
+ *     assistant placeholder, POST `/api/generate`, then rely on the
+ *     EventSource to deliver the stream.
+ *   - On `chunk`: feed the bytes to `createMixedStreamParser`. Prose
+ *     tokens grow the assistant placeholder; JSON patches update the
+ *     spec.
+ *   - On `done`: stop streaming. The DB has the final state; we leave
+ *     local state alone (it already mirrors the parsed buffer).
  */
 export const useDecoroChat = ({
   api,
-  persistApi = '/api/conversations',
+  eventsApi = '/api/conversations',
   initialState = null,
   initialConversationId = null,
   onConversationCreated,
@@ -90,77 +108,162 @@ export const useDecoroChat = ({
         }
       : emptyState,
   );
-  const messagesRef = useRef<DecoroMessage[]>([]);
+  const messagesRef = useRef<DecoroMessage[]>(state.messages);
   messagesRef.current = state.messages;
-  const specRef = useRef<Spec | null>(null);
+  const specRef = useRef<Spec | null>(state.spec);
   specRef.current = state.spec;
-  const abortRef = useRef<AbortController | null>(null);
-  // The conversation row id grows out-of-band from React state — once
-  // assigned by the first POST, every subsequent save needs the same id
-  // even across renders that haven't committed yet. A ref keeps it
-  // synchronously available without forcing a re-render that doesn't
-  // change anything visible.
   const conversationIdRef = useRef<string | null>(initialConversationId);
-  // Latest callback in a ref so changing it across renders doesn't
-  // invalidate `persist` (which is in `send`'s dep list).
   const onCreatedRef = useRef(onConversationCreated);
   onCreatedRef.current = onConversationCreated;
 
-  const persist = useCallback(
-    async (messages: DecoroMessage[], spec: Spec | null) => {
-      if (persistApi === null || persistApi === '') return;
-      // Guard against persisting before the first turn fully resolves.
-      // A null spec from an aborted-mid-stream save would round-trip as
-      // an invalid record; skip those.
-      if (!spec || spec.root === '') return;
-      try {
-        const body = JSON.stringify({ messages, spec });
-        if (conversationIdRef.current === null) {
-          const res = await fetch(persistApi, {
-            method: 'POST',
-            headers: { 'content-type': 'application/json' },
-            body,
-          });
-          if (!res.ok) throw new Error(`POST ${res.status.toString()}`);
-          const data = (await res.json()) as { id: string };
-          conversationIdRef.current = data.id;
-          onCreatedRef.current?.(data.id);
-          return;
-        }
-        const res = await fetch(`${persistApi}/${conversationIdRef.current}`, {
-          method: 'PATCH',
-          headers: { 'content-type': 'application/json' },
-          body,
-        });
-        if (!res.ok) throw new Error(`PATCH ${res.status.toString()}`);
-      } catch (err) {
-        // Auto-save failure is a background concern; log it but keep
-        // the chat alive. The user's in-memory state is still good and
-        // the next turn will retry.
-        console.warn('[useDecoroChat] persist failed:', err);
+  // Track the current assistant placeholder + working spec so chunks
+  // for the active turn land in the right places. These are recreated
+  // on every `start` event so a server-side cancellation (a fresh turn
+  // supersedes the previous one) cleanly resets the parser.
+  const turnRef = useRef<{
+    turnId: string | null;
+    assistantId: string | null;
+    working: Spec;
+    parser: ReturnType<typeof createMixedStreamParser> | null;
+  }>({
+    turnId: null,
+    assistantId: null,
+    working: buildEmptySpec(),
+    parser: null,
+  });
+
+  const ensureTurnContext = useCallback((turnId: string) => {
+    const existing = turnRef.current;
+    if (existing.turnId === turnId && existing.parser) return;
+    // New turn (or first chunk for this connection). Build an empty
+    // assistant placeholder if one isn't already present, and reset
+    // the parser around a fresh working spec seeded from current state.
+    let assistantId: string | null = null;
+    setState((prev) => {
+      // Re-use the trailing empty assistant placeholder if the user's
+      // own send() already inserted one in this same browser tab.
+      const last = prev.messages.at(-1);
+      if (last?.role === 'assistant' && last.text === '') {
+        assistantId = last.id;
+        return prev;
       }
-    },
-    [persistApi],
-  );
+      // Otherwise this stream came from another tab / a server-side
+      // job we're just attaching to. Insert a placeholder of our own.
+      const id = crypto.randomUUID();
+      assistantId = id;
+      return {
+        ...prev,
+        messages: [...prev.messages, { id, role: 'assistant', text: '' }],
+        isStreaming: true,
+        error: null,
+      };
+    });
+    const working = cloneSpec(specRef.current);
+    const parser = createMixedStreamParser({
+      onText(chunk) {
+        const id = assistantId;
+        if (id === null) return;
+        setState((prev) => ({
+          ...prev,
+          messages: prev.messages.map((m) =>
+            m.id === id ? { ...m, text: m.text + chunk } : m,
+          ),
+        }));
+      },
+      onPatch(patch) {
+        applySpecPatch(working, patch);
+        setState((prev) => ({
+          ...prev,
+          spec: cloneSpec(working),
+        }));
+      },
+    });
+    turnRef.current = { turnId, assistantId, working, parser };
+  }, []);
+
+  // EventSource lifecycle. Re-subscribe whenever the conversation id
+  // changes (sidebar pick, fork, new chat). The EventSource itself
+  // auto-reconnects on transient network errors; we only manually open
+  // / close on conversation switches.
+  useEffect(() => {
+    const conversationId = conversationIdRef.current;
+    if (
+      conversationId === null ||
+      conversationId === '' ||
+      eventsApi === null ||
+      eventsApi === ''
+    ) {
+      return undefined;
+    }
+    const source = new EventSource(`${eventsApi}/${conversationId}/events`);
+    const handler = (ev: MessageEvent<string>) => {
+      let event: StreamEvent;
+      try {
+        event = JSON.parse(ev.data) as StreamEvent;
+      } catch {
+        return;
+      }
+      if (event.type === 'start') {
+        // Fresh turn started server-side. Reset our parser for it.
+        turnRef.current = {
+          turnId: event.turnId,
+          assistantId: null,
+          working: buildEmptySpec(),
+          parser: null,
+        };
+        setState((prev) => ({ ...prev, isStreaming: true, error: null }));
+        return;
+      }
+      if (event.type === 'chunk') {
+        ensureTurnContext(event.turnId);
+        turnRef.current.parser?.push(event.text);
+        return;
+      }
+      if (event.type === 'done') {
+        turnRef.current.parser?.flush();
+        setState((prev) => ({ ...prev, isStreaming: false }));
+        // Don't tear down the EventSource — leaving it open lets the
+        // next turn (in this conversation) attach instantly. The server
+        // emits a synthetic `done` for idle conversations on subscribe,
+        // so re-opening would be cheap, but staying open is cheaper.
+        return;
+      }
+      // Remaining variant is `error` (the event union is exhausted by
+      // the earlier returns); narrowing makes lint think the explicit
+      // check is redundant, so we destructure unconditionally.
+      setState((prev) => ({
+        ...prev,
+        isStreaming: false,
+        error: new Error(event.message),
+      }));
+    };
+    source.addEventListener('message', handler);
+    source.addEventListener('error', () => {
+      // EventSource auto-reconnects on transient errors. If the
+      // connection is permanently closed (server gone), the readyState
+      // becomes CLOSED and no further events arrive.
+    });
+    return () => {
+      source.removeEventListener('message', handler);
+      source.close();
+    };
+    // We deliberately depend on `conversationIdRef.current` indirectly
+    // via the `state.messages.length === 0` heuristic re-run trigger
+    // below — but the cleanest is to re-run when the active id changes.
+    // Read it from the ref so a value change forces a re-effect.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- ref read is intentional
+  }, [eventsApi, ensureTurnContext, conversationIdRef.current]);
 
   const send = useCallback(
     async (text: string) => {
       const trimmed = text.trim();
       if (!trimmed) return;
 
-      abortRef.current?.abort();
-      abortRef.current = new AbortController();
-
       const userMsg: DecoroMessage = {
         id: crypto.randomUUID(),
         role: 'user',
         text: trimmed,
       };
-      // Append the assistant placeholder up front so prose tokens streamed in
-      // via `onText` (the LLM's 1-line summary, see api/generate route) can
-      // grow it character-by-character. Previously the assistant entry was
-      // appended *after* the stream completed and always carried empty text,
-      // so the chat pane fell back to a "rendered →" marker.
       const assistantId = crypto.randomUUID();
       setState((prev) => ({
         ...prev,
@@ -173,85 +276,31 @@ export const useDecoroChat = ({
         error: null,
       }));
 
-      const messagesForApi = [...messagesRef.current, userMsg].map((m) => ({
-        role: m.role,
-        content: m.text,
-      }));
-
-      // Mint the conversation row up front (in parallel with the LLM
-      // stream) so the URL can update before the assistant has even
-      // started responding. Without this, the URL only changes when
-      // the stream completes — which is after several seconds of LLM
-      // latency. Falls back gracefully: if this POST fails, the
-      // post-stream `persist()` call below will retry.
-      const earlyCreate: Promise<void> | null =
-        conversationIdRef.current === null &&
-        persistApi !== null &&
-        persistApi !== ''
-          ? (async () => {
-              try {
-                const res = await fetch(persistApi, {
-                  method: 'POST',
-                  headers: { 'content-type': 'application/json' },
-                  body: JSON.stringify({
-                    messages: [...messagesRef.current, userMsg],
-                    spec: specRef.current ?? { root: '', elements: {} },
-                  }),
-                });
-                if (!res.ok) throw new Error(`POST ${res.status.toString()}`);
-                const data = (await res.json()) as { id: string };
-                conversationIdRef.current = data.id;
-                onCreatedRef.current?.(data.id);
-              } catch (err) {
-                console.warn('[useDecoroChat] early create failed:', err);
-              }
-            })()
-          : null;
-
-      const working: Spec = specRef.current
-        ? structuredClone(specRef.current)
-        : { root: '', elements: {} };
-      const parser = createMixedStreamParser({
-        onPatch(patch) {
-          applySpecPatch(working, patch);
-          setState((prev) => ({
-            ...prev,
-            spec: {
-              root: working.root,
-              elements: { ...working.elements },
-              ...(working.state ? { state: { ...working.state } } : {}),
-            },
-          }));
-        },
-        onText(chunk) {
-          // The system prompt tells the model to emit one short prose line
-          // before the JSONL patches (see api/generate route). Append the
-          // chunk to the assistant placeholder so the chat pane reflects the
-          // model's running summary as it streams in.
-          setState((prev) => ({
-            ...prev,
-            messages: prev.messages.map((m) =>
-              m.id === assistantId ? { ...m, text: m.text + chunk } : m,
-            ),
-          }));
-        },
-      });
+      // Snapshot what the API needs from refs (post-render values).
+      // The trailing empty assistant placeholder is sent through too —
+      // the server filters it before calling the LLM but uses it as
+      // the placeholder anchor for the assistant turn.
+      const messagesForApi = [
+        ...messagesRef.current,
+        userMsg,
+        { id: assistantId, role: 'assistant' as const, text: '' },
+      ];
+      const specForApi = specRef.current ?? buildEmptySpec();
 
       try {
-        const response = await fetch(api, {
+        const res = await fetch(api, {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
           body: JSON.stringify({
+            conversationId: conversationIdRef.current,
             messages: messagesForApi,
-            currentSpec: specRef.current,
+            spec: specForApi,
           }),
-          signal: abortRef.current.signal,
         });
-
-        if (!response.ok || !response.body) {
-          let message = `HTTP ${response.status.toString()}`;
+        if (!res.ok) {
+          let message = `HTTP ${res.status.toString()}`;
           try {
-            const data = (await response.json()) as {
+            const data = (await res.json()) as {
               message?: string;
               error?: string;
             };
@@ -261,35 +310,27 @@ export const useDecoroChat = ({
           }
           throw new Error(message);
         }
-
-        for await (const chunk of response.body.pipeThrough(
-          new TextDecoderStream(),
-        )) {
-          parser.push(chunk);
+        const data = (await res.json()) as { conversationId: string };
+        if (conversationIdRef.current === null) {
+          conversationIdRef.current = data.conversationId;
+          onCreatedRef.current?.(data.conversationId);
         }
-        parser.flush();
-
-        setState((prev) => ({ ...prev, isStreaming: false }));
-        // Wait for the early-create POST (if any) to settle before the
-        // post-stream save fires, so `persist()` sees the row id and
-        // takes the PATCH branch instead of POSTing a duplicate.
-        if (earlyCreate) await earlyCreate;
-        // Fire-and-forget the auto-save now that the stream has settled.
-        // Reads from refs to capture the latest state without depending on
-        // a re-render landing first.
-        void persist(messagesRef.current, specRef.current);
       } catch (err) {
-        if ((err as Error).name === 'AbortError') return;
         const error = err instanceof Error ? err : new Error(String(err));
         setState((prev) => ({ ...prev, isStreaming: false, error }));
       }
     },
-    [api, persist, persistApi],
+    [api],
   );
 
   const clear = useCallback(() => {
-    abortRef.current?.abort();
     conversationIdRef.current = null;
+    turnRef.current = {
+      turnId: null,
+      assistantId: null,
+      working: buildEmptySpec(),
+      parser: null,
+    };
     setState(emptyState);
   }, []);
 
@@ -300,3 +341,15 @@ export const useDecoroChat = ({
     clear,
   };
 };
+
+/**
+ * Helper consumed by HomeShell to seed the hook from a `ConversationRecord`
+ * fetched from `/api/conversations/[id]`. Centralizes the type-cast so
+ * we don't repeat the `as` shape in every caller.
+ */
+export const seedFromConversation = (
+  record: ConversationRecord,
+): { messages: DecoroMessage[]; spec: Spec | null } => ({
+  messages: record.messages,
+  spec: record.spec as unknown as Spec,
+});

--- a/apps/web/src/lib/use-decoro-chat.ts
+++ b/apps/web/src/lib/use-decoro-chat.ts
@@ -15,6 +15,26 @@ export type DecoroMessage = {
 
 type Options = {
   api: string;
+  /**
+   * Persistence endpoint base. The hook POSTs once to `${persistApi}` to
+   * mint a conversation row on the first stream completion, then PATCHes
+   * `${persistApi}/<id>` on every subsequent assistant turn. Pass `null`
+   * to disable persistence (e.g. demo / test contexts).
+   */
+  persistApi?: string | null;
+  /**
+   * Optional seed for the chat state. Used when continuing from a shared
+   * snapshot or resuming a conversation from the sidebar. When supplied,
+   * `conversationId` should also be set so subsequent saves PATCH the
+   * existing row instead of creating a new one.
+   */
+  initialState?: { messages: DecoroMessage[]; spec: Spec | null } | null;
+  /**
+   * Existing conversation row id. When set, the first assistant-turn
+   * save is a PATCH (instead of POST). Forks from a shared snapshot
+   * leave this unset — the first save then creates a brand-new row.
+   */
+  initialConversationId?: string | null;
 };
 
 type State = {
@@ -24,7 +44,7 @@ type State = {
   error: Error | null;
 };
 
-const initialState: State = {
+const emptyState: State = {
   messages: [],
   spec: null,
   isStreaming: false,
@@ -37,14 +57,78 @@ const initialState: State = {
  * `currentSpec` alongside the message history — `useChatUI` from
  * `@json-render/react` is otherwise a perfect fit but its request body is
  * locked to `{ messages }`, which prevents the iteration loop M8 needs.
+ *
+ * Persistence (per ADR-015): when `persistApi` is set, the hook saves
+ * the conversation to Postgres after each assistant turn completes. The
+ * first save POSTs to mint a new row; subsequent saves PATCH the same id.
+ * Failures are logged but never break the chat experience — losing a
+ * single auto-save is annoying but recoverable, while propagating the
+ * error to the UI would interrupt a working stream for a background
+ * concern.
  */
-export const useDecoroChat = ({ api }: Options) => {
-  const [state, setState] = useState<State>(initialState);
+export const useDecoroChat = ({
+  api,
+  persistApi = '/api/conversations',
+  initialState = null,
+  initialConversationId = null,
+}: Options) => {
+  const [state, setState] = useState<State>(() =>
+    initialState
+      ? {
+          messages: initialState.messages,
+          spec: initialState.spec,
+          isStreaming: false,
+          error: null,
+        }
+      : emptyState,
+  );
   const messagesRef = useRef<DecoroMessage[]>([]);
   messagesRef.current = state.messages;
   const specRef = useRef<Spec | null>(null);
   specRef.current = state.spec;
   const abortRef = useRef<AbortController | null>(null);
+  // The conversation row id grows out-of-band from React state — once
+  // assigned by the first POST, every subsequent save needs the same id
+  // even across renders that haven't committed yet. A ref keeps it
+  // synchronously available without forcing a re-render that doesn't
+  // change anything visible.
+  const conversationIdRef = useRef<string | null>(initialConversationId);
+
+  const persist = useCallback(
+    async (messages: DecoroMessage[], spec: Spec | null) => {
+      if (persistApi === null || persistApi === '') return;
+      // Guard against persisting before the first turn fully resolves.
+      // A null spec from an aborted-mid-stream save would round-trip as
+      // an invalid record; skip those.
+      if (!spec || spec.root === '') return;
+      try {
+        const body = JSON.stringify({ messages, spec });
+        if (conversationIdRef.current === null) {
+          const res = await fetch(persistApi, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body,
+          });
+          if (!res.ok) throw new Error(`POST ${res.status.toString()}`);
+          const data = (await res.json()) as { id: string };
+          conversationIdRef.current = data.id;
+          return;
+        }
+        const res = await fetch(`${persistApi}/${conversationIdRef.current}`, {
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body,
+        });
+        if (!res.ok) throw new Error(`PATCH ${res.status.toString()}`);
+      } catch (err) {
+        // Auto-save failure is a background concern; log it but keep
+        // the chat alive. The user's in-memory state is still good and
+        // the next turn will retry.
+        console.warn('[useDecoroChat] persist failed:', err);
+      }
+    },
+    [persistApi],
+  );
 
   const send = useCallback(
     async (text: string) => {
@@ -143,19 +227,29 @@ export const useDecoroChat = ({ api }: Options) => {
         parser.flush();
 
         setState((prev) => ({ ...prev, isStreaming: false }));
+        // Fire-and-forget the auto-save now that the stream has settled.
+        // Reads from refs to capture the latest state without depending on
+        // a re-render landing first.
+        void persist(messagesRef.current, specRef.current);
       } catch (err) {
         if ((err as Error).name === 'AbortError') return;
         const error = err instanceof Error ? err : new Error(String(err));
         setState((prev) => ({ ...prev, isStreaming: false, error }));
       }
     },
-    [api],
+    [api, persist],
   );
 
   const clear = useCallback(() => {
     abortRef.current?.abort();
-    setState(initialState);
+    conversationIdRef.current = null;
+    setState(emptyState);
   }, []);
 
-  return { ...state, send, clear };
+  return {
+    ...state,
+    conversationId: conversationIdRef.current,
+    send,
+    clear,
+  };
 };

--- a/apps/web/src/lib/use-decoro-chat.ts
+++ b/apps/web/src/lib/use-decoro-chat.ts
@@ -178,6 +178,36 @@ export const useDecoroChat = ({
         content: m.text,
       }));
 
+      // Mint the conversation row up front (in parallel with the LLM
+      // stream) so the URL can update before the assistant has even
+      // started responding. Without this, the URL only changes when
+      // the stream completes — which is after several seconds of LLM
+      // latency. Falls back gracefully: if this POST fails, the
+      // post-stream `persist()` call below will retry.
+      const earlyCreate: Promise<void> | null =
+        conversationIdRef.current === null &&
+        persistApi !== null &&
+        persistApi !== ''
+          ? (async () => {
+              try {
+                const res = await fetch(persistApi, {
+                  method: 'POST',
+                  headers: { 'content-type': 'application/json' },
+                  body: JSON.stringify({
+                    messages: [...messagesRef.current, userMsg],
+                    spec: specRef.current ?? { root: '', elements: {} },
+                  }),
+                });
+                if (!res.ok) throw new Error(`POST ${res.status.toString()}`);
+                const data = (await res.json()) as { id: string };
+                conversationIdRef.current = data.id;
+                onCreatedRef.current?.(data.id);
+              } catch (err) {
+                console.warn('[useDecoroChat] early create failed:', err);
+              }
+            })()
+          : null;
+
       const working: Spec = specRef.current
         ? structuredClone(specRef.current)
         : { root: '', elements: {} };
@@ -240,6 +270,10 @@ export const useDecoroChat = ({
         parser.flush();
 
         setState((prev) => ({ ...prev, isStreaming: false }));
+        // Wait for the early-create POST (if any) to settle before the
+        // post-stream save fires, so `persist()` sees the row id and
+        // takes the PATCH branch instead of POSTing a duplicate.
+        if (earlyCreate) await earlyCreate;
         // Fire-and-forget the auto-save now that the stream has settled.
         // Reads from refs to capture the latest state without depending on
         // a re-render landing first.
@@ -250,7 +284,7 @@ export const useDecoroChat = ({
         setState((prev) => ({ ...prev, isStreaming: false, error }));
       }
     },
-    [api, persist],
+    [api, persist, persistApi],
   );
 
   const clear = useCallback(() => {

--- a/apps/web/src/lib/use-preview-broadcast.ts
+++ b/apps/web/src/lib/use-preview-broadcast.ts
@@ -1,0 +1,62 @@
+'use client';
+
+import type { Spec } from '@json-render/core';
+import { useEffect, useRef } from 'react';
+
+import {
+  PREVIEW_CHANNEL,
+  type PreviewSpecMessage,
+  isPreviewMessage,
+} from './preview-message.ts';
+
+/**
+ * Owns the publisher side of the preview BroadcastChannel.
+ *
+ * - Whenever `spec` changes, broadcasts `decoro:spec` so every preview
+ *   surface — the embedded iframe AND any popped-out windows — updates
+ *   in lockstep.
+ * - Listens for `decoro:ready` so a freshly-mounted consumer (e.g. a
+ *   popout that just opened) can request the current spec without
+ *   waiting for the next change.
+ *
+ * `spec === null` is left un-broadcast so consumers stay in their built-in
+ * "Waiting for a spec…" empty state rather than receiving a partial-render
+ * signal.
+ */
+export const usePreviewBroadcast = (spec: Spec | null) => {
+  const specRef = useRef<Spec | null>(spec);
+  specRef.current = spec;
+
+  useEffect(() => {
+    const channel = new BroadcastChannel(PREVIEW_CHANNEL);
+    const handler = (event: MessageEvent) => {
+      if (!isPreviewMessage(event.data)) return;
+      if (event.data.type !== 'decoro:ready') return;
+      const { current } = specRef;
+      if (!current) return;
+      const message: PreviewSpecMessage = {
+        type: 'decoro:spec',
+        spec: current,
+      };
+      // BroadcastChannel.postMessage takes only the message; the
+      // targetOrigin arg the lint rule wants is for window.postMessage.
+      // oxlint-disable-next-line eslint-plugin-unicorn(require-post-message-target-origin)
+      channel.postMessage(message);
+    };
+    channel.addEventListener('message', handler);
+    return () => {
+      channel.removeEventListener('message', handler);
+      channel.close();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!spec) return;
+    const channel = new BroadcastChannel(PREVIEW_CHANNEL);
+    const message: PreviewSpecMessage = { type: 'decoro:spec', spec };
+    // BroadcastChannel.postMessage takes only the message; see comment above.
+    // oxlint-disable-next-line eslint-plugin-unicorn(require-post-message-target-origin)
+    channel.postMessage(message);
+    channel.close();
+  }, [spec]);
+};

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,22 @@
+name: decoro
+
+services:
+  postgres:
+    image: postgres:17-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: decoro
+      POSTGRES_PASSWORD: decoro
+      POSTGRES_DB: decoro
+    ports:
+      # Default Postgres port. Change here (and in apps/web/.env.local
+      # DATABASE_URL) if 5432 collides with a Postgres you're already
+      # running locally.
+      - '5432:5432'
+    volumes:
+      - ./.postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U decoro -d decoro']
+      interval: 5s
+      timeout: 5s
+      retries: 5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,7 +79,7 @@ importers:
         version: 6.0.3
       vite-plus:
         specifier: 'catalog:'
-        version: 0.1.19(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jiti@2.6.1)(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))
+        version: 0.1.19(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
 
   apps/web:
     dependencies:
@@ -107,9 +107,15 @@ importers:
       ai:
         specifier: 6.0.168
         version: 6.0.168(zod@4.3.6)
+      drizzle-orm:
+        specifier: 0.45.2
+        version: 0.45.2(@opentelemetry/api@1.9.0)(postgres@3.4.9)
       next:
         specifier: 16.2.4
         version: 16.2.4(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      postgres:
+        specifier: 3.4.9
+        version: 3.4.9
       react:
         specifier: 'catalog:'
         version: 19.2.5
@@ -138,9 +144,15 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.14)
+      drizzle-kit:
+        specifier: 0.31.10
+        version: 0.31.10
       postcss:
         specifier: '>=8.5.10'
         version: 8.5.12
+      tsx:
+        specifier: 4.21.0
+        version: 4.21.0
 
   packages/adapter-arte-odyssey:
     dependencies:
@@ -174,7 +186,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 6.0.1(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))
+        version: 6.0.1(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
       react-dom:
         specifier: 'catalog:'
         version: 19.2.5(react@19.2.5)
@@ -329,6 +341,9 @@ packages:
       conventional-commits-parser:
         optional: true
 
+  '@drizzle-team/brocli@0.10.2':
+    resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
@@ -337,6 +352,458 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@esbuild-kit/core-utils@3.3.2':
+    resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
+    deprecated: 'Merged into tsx: https://tsx.is'
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
+    deprecated: 'Merged into tsx: https://tsx.is'
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.18.20':
+    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.18.20':
+    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.18.20':
+    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.18.20':
+    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.18.20':
+    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.18.20':
+    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.18.20':
+    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.18.20':
+    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.18.20':
+    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.18.20':
+    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.18.20':
+    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.18.20':
+    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.18.20':
+    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.18.20':
+    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.18.20':
+    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.18.20':
+    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.18.20':
+    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.18.20':
+    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.18.20':
+    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.18.20':
+    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.18.20':
+    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.18.20':
+    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -1399,6 +1866,9 @@ packages:
   baseline-status@1.1.1:
     resolution: {integrity: sha512-l7L5D3MQA/+082HNaN2vEeodO20wVC6SctPCPmediuxHlGkBxQcbo2fYfTB+4FYg4QbRTTig4xI5Tyy1aRCJ3A==}
 
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -1487,6 +1957,102 @@ packages:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
     engines: {node: '>=8'}
 
+  drizzle-kit@0.31.10:
+    resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
+    hasBin: true
+
+  drizzle-orm@0.45.2:
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=4'
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1.13'
+      '@prisma/client': '*'
+      '@tidbcloud/serverless': '*'
+      '@types/better-sqlite3': '*'
+      '@types/pg': '*'
+      '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      better-sqlite3: '>=7'
+      bun-types: '*'
+      expo-sqlite: '>=14.0.0'
+      gel: '>=2'
+      knex: '*'
+      kysely: '*'
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      prisma: '*'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      expo-sqlite:
+        optional: true
+      gel:
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      prisma:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -1503,6 +2069,21 @@ packages:
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.18.20:
+    resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -1549,6 +2130,9 @@ packages:
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
   git-raw-commits@5.0.1:
     resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
@@ -1865,6 +2449,10 @@ packages:
     resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postgres@3.4.9:
+    resolution: {integrity: sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw==}
+    engines: {node: '>=12'}
+
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
@@ -1902,6 +2490,9 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   rolldown@1.0.0-rc.17:
     resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1932,6 +2523,13 @@ packages:
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
   space-separated-tokens@2.0.2:
@@ -2001,6 +2599,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
@@ -2277,6 +2880,8 @@ snapshots:
     optionalDependencies:
       conventional-commits-parser: 6.4.0
 
+  '@drizzle-team/brocli@0.10.2': {}
+
   '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -2291,6 +2896,238 @@ snapshots:
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild-kit/core-utils@3.3.2':
+    dependencies:
+      esbuild: 0.18.20
+      source-map-support: 0.5.21
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    dependencies:
+      '@esbuild-kit/core-utils': 3.3.2
+      get-tsconfig: 4.14.0
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.18.20':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.18.20':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.18.20':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.18.20':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.18.20':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.18.20':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.18.20':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.18.20':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.18.20':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.18.20':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@floating-ui/core@1.7.5':
@@ -2875,12 +3712,12 @@ snapshots:
 
   '@vercel/oidc@3.2.0': {}
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.10(@types/node@24.12.2)(jiti@2.6.1)
+      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)
 
-  '@voidzero-dev/vite-plus-core@0.1.19(@types/node@24.12.2)(jiti@2.6.1)(typescript@6.0.3)':
+  '@voidzero-dev/vite-plus-core@0.1.19(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(typescript@6.0.3)':
     dependencies:
       '@oxc-project/runtime': 0.126.0
       '@oxc-project/types': 0.126.0
@@ -2888,8 +3725,10 @@ snapshots:
       postcss: 8.5.12
     optionalDependencies:
       '@types/node': 24.12.2
+      esbuild: 0.27.7
       fsevents: 2.3.3
       jiti: 2.6.1
+      tsx: 4.21.0
       typescript: 6.0.3
 
   '@voidzero-dev/vite-plus-darwin-arm64@0.1.19':
@@ -2910,11 +3749,11 @@ snapshots:
   '@voidzero-dev/vite-plus-linux-x64-musl@0.1.19':
     optional: true
 
-  '@voidzero-dev/vite-plus-test@0.1.19(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jiti@2.6.1)(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))':
+  '@voidzero-dev/vite-plus-test@0.1.19(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@voidzero-dev/vite-plus-core': 0.1.19(@types/node@24.12.2)(jiti@2.6.1)(typescript@6.0.3)
+      '@voidzero-dev/vite-plus-core': 0.1.19(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(typescript@6.0.3)
       es-module-lexer: 1.7.0
       obug: 2.1.1
       pixelmatch: 7.1.0
@@ -2924,7 +3763,7 @@ snapshots:
       tinybench: 2.9.0
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
-      vite: 8.0.10(@types/node@24.12.2)(jiti@2.6.1)
+      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)
       ws: 8.20.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
@@ -2989,6 +3828,8 @@ snapshots:
     dependencies:
       '@lit/task': 1.0.3
       lit: 3.3.2
+
+  buffer-from@1.1.2: {}
 
   callsites@3.1.0: {}
 
@@ -3066,6 +3907,18 @@ snapshots:
     dependencies:
       is-obj: 2.0.0
 
+  drizzle-kit@0.31.10:
+    dependencies:
+      '@drizzle-team/brocli': 0.10.2
+      '@esbuild-kit/esm-loader': 2.6.5
+      esbuild: 0.25.12
+      tsx: 4.21.0
+
+  drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(postgres@3.4.9):
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      postgres: 3.4.9
+
   emoji-regex@8.0.0: {}
 
   enhanced-resolve@5.21.0:
@@ -3080,6 +3933,89 @@ snapshots:
       is-arrayish: 0.2.1
 
   es-module-lexer@1.7.0: {}
+
+  esbuild@0.18.20:
+    optionalDependencies:
+      '@esbuild/android-arm': 0.18.20
+      '@esbuild/android-arm64': 0.18.20
+      '@esbuild/android-x64': 0.18.20
+      '@esbuild/darwin-arm64': 0.18.20
+      '@esbuild/darwin-x64': 0.18.20
+      '@esbuild/freebsd-arm64': 0.18.20
+      '@esbuild/freebsd-x64': 0.18.20
+      '@esbuild/linux-arm': 0.18.20
+      '@esbuild/linux-arm64': 0.18.20
+      '@esbuild/linux-ia32': 0.18.20
+      '@esbuild/linux-loong64': 0.18.20
+      '@esbuild/linux-mips64el': 0.18.20
+      '@esbuild/linux-ppc64': 0.18.20
+      '@esbuild/linux-riscv64': 0.18.20
+      '@esbuild/linux-s390x': 0.18.20
+      '@esbuild/linux-x64': 0.18.20
+      '@esbuild/netbsd-x64': 0.18.20
+      '@esbuild/openbsd-x64': 0.18.20
+      '@esbuild/sunos-x64': 0.18.20
+      '@esbuild/win32-arm64': 0.18.20
+      '@esbuild/win32-ia32': 0.18.20
+      '@esbuild/win32-x64': 0.18.20
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
 
   escalade@3.2.0: {}
 
@@ -3106,6 +4042,10 @@ snapshots:
     optional: true
 
   get-caller-file@2.0.5: {}
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   git-raw-commits@5.0.1(conventional-commits-parser@6.4.0):
     dependencies:
@@ -3434,6 +4374,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postgres@3.4.9: {}
+
   property-information@7.1.0: {}
 
   react-dom@19.2.5(react@19.2.5):
@@ -3460,6 +4402,8 @@ snapshots:
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
 
   rolldown@1.0.0-rc.17:
     dependencies:
@@ -3539,6 +4483,13 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
+  source-map@0.6.1: {}
+
   space-separated-tokens@2.0.2: {}
 
   std-env@4.1.0: {}
@@ -3588,6 +4539,13 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   typescript@6.0.3: {}
 
   undici-types@7.16.0: {}
@@ -3625,11 +4583,11 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plus@0.1.19(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jiti@2.6.1)(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1)):
+  vite-plus@0.1.19(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)):
     dependencies:
       '@oxc-project/types': 0.126.0
-      '@voidzero-dev/vite-plus-core': 0.1.19(@types/node@24.12.2)(jiti@2.6.1)(typescript@6.0.3)
-      '@voidzero-dev/vite-plus-test': 0.1.19(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jiti@2.6.1)(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1))
+      '@voidzero-dev/vite-plus-core': 0.1.19(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(typescript@6.0.3)
+      '@voidzero-dev/vite-plus-test': 0.1.19(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
       oxfmt: 0.45.0
       oxlint: 1.60.0(oxlint-tsgolint@0.21.1)
       oxlint-tsgolint: 0.21.1
@@ -3672,7 +4630,7 @@ snapshots:
       - vite
       - yaml
 
-  vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1):
+  vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -3681,8 +4639,10 @@ snapshots:
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 24.12.2
+      esbuild: 0.27.7
       fsevents: 2.3.3
       jiti: 2.6.1
+      tsx: 4.21.0
 
   wrap-ansi@7.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

Two intertwined chunks of work that turn Decoro from a single-tab,
in-memory chat into a team-self-host experience that survives
navigation, tab close, refresh, and multi-user viewing.

### 1. Persistence is PostgreSQL via Drizzle (ADR-015)

- `compose.yml` at the repo root spins up Postgres 17 for local dev.
- New `apps/web/src/lib/db/` holds the Drizzle schema (`shares` +
  `conversations`), client, and a one-shot `pnpm migrate:from-fs`
  script that ingests legacy `.decoro-shares/*.json` files.
- `share-store.ts` swapped from filesystem to Postgres with the same
  exported API (route handlers untouched). Adds a `parent_share_id`
  column for fork lineage.
- New `conversation-store.ts` + `/api/conversations` (GET / POST)
  + `/api/conversations/[id]` (GET / PATCH / DELETE).
- `useDecoroChat` gains seed-from-initial-state + auto-persist on
  every assistant turn.
- `HomeShell` gains a left-rail conversations sidebar, URL persistence
  (`/?conversation=<id>` survives refresh), and `/?from=<shareId>`
  seeds a fresh conversation from a shared snapshot.
- ShareView gains a "Continue this conversation →" link.

### 2. Server-side streaming via SSE (ADR-016)

- The LLM stream moves from a browser `fetch` to a server-side
  background job in an in-memory store keyed by `conversationId`.
- `POST /api/generate` returns `{ conversationId }` immediately;
  `GET /api/conversations/[id]/events` (SSE) delivers chunks.
- `useDecoroChat` consumes the stream over `EventSource`, keeping
  the existing `createMixedStreamParser` pipeline in place.
- Sidebar shows a spinner badge for any conversation currently
  generating in the background — including ones the operator isn't
  looking at right now.
- Mid-stream navigation, tab close, and refresh are now non-
  destructive: the job runs to completion server-side and PATCHes
  the row when it finishes.

### 3. Smaller polish

- Preview popout via BroadcastChannel — \"Open preview in a new
  window\" button.
- 8k-token output cap on `streamText` to bound runaway turns
  (model occasionally loops on the response-format preamble).

## Why now

The earlier shape — chat in memory, share as the only persistence —
broke the moment the operator did anything but type-and-watch:
clicking another sidebar conversation killed the in-flight turn,
refresh wiped state, and a teammate opening the share URL saw a
read-only snapshot they couldn't pick up. concept.md describes a
team driving the tool together in a meeting; that experience is
infeasible without per-team history + shared live streams. Both ADRs
go through the alternatives we considered and why we landed on the
specific shapes above.

## Operator impact

- New env var: \`DATABASE_URL\` in \`apps/web/.env.local\` (default
  matches the local \`compose.yml\`).
- Setup once: \`docker compose up -d\` from the repo root + \`pnpm
  db:migrate\` from \`apps/web\`. Documented in \`.env.example\`.
- Existing share JSONs migrate via \`pnpm migrate:from-fs\`
  (idempotent — safe to re-run).

## Test plan

- [ ] \`docker compose up -d\` then \`pnpm db:migrate\` succeeds on a
      fresh checkout.
- [ ] \`pnpm migrate:from-fs\` ingests existing \`.decoro-shares/\`
      and is idempotent on re-run.
- [ ] Send a turn → URL updates to \`?conversation=<id>\` within a
      few hundred ms; refresh stays on the same conversation.
- [ ] Click another sidebar conversation mid-stream → spinner stays
      on the original; coming back shows the completed result.
- [ ] Open the same conversation URL in a second tab mid-stream →
      both tabs receive live chunks.
- [ ] Click \"Continue this conversation →\" on a share page → fork
      lands in a new conversation row, original share unchanged.
- [ ] \"Open preview in a new window\" button keeps the popped-out
      preview in sync as turns happen in the main window.
- [ ] Force a long output → stream stops cleanly at the 8k cap; the
      partial spec (whatever was emitted before the cap) persists.